### PR TITLE
⭐ Structured logger with per-component prefixes

### DIFF
--- a/cmd/beacon/cloud.go
+++ b/cmd/beacon/cloud.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"syscall"
@@ -35,14 +34,14 @@ Or: BEACON_API_KEY=usr_... beacon cloud login`,
 		Short: "Clear API key from config and set cloud_reporting_enabled to false",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := identity.WriteCloudLogout(); err != nil {
-				log.Fatalf("beacon cloud logout: %v", err)
+				logger.Fatalf("beacon cloud logout: %v", err)
 			}
 			p, err := identity.UserConfigPath()
 			if err != nil {
-				log.Printf("[Beacon] Updated cloud settings")
+				logger.Infof("Updated cloud settings")
 				return
 			}
-			log.Printf("[Beacon] Cleared cloud credentials in %s", p)
+			logger.Infof("Cleared cloud credentials in %s", p)
 		},
 	}
 
@@ -64,12 +63,12 @@ func runCloudLogin(cmd *cobra.Command, args []string) {
 			fmt.Fprint(os.Stderr, "BeaconInfra API key: ")
 			b, err := term.ReadPassword(syscall.Stdin)
 			if err != nil {
-				log.Fatalf("beacon cloud login: read API key: %v", err)
+				logger.Fatalf("beacon cloud login: read API key: %v", err)
 			}
 			apiKey = strings.TrimSpace(string(b))
 			fmt.Fprintln(os.Stderr)
 		} else {
-			log.Fatal("beacon cloud login: non-interactive terminal; use --api-key or set BEACON_API_KEY")
+			logger.Fatalf("beacon cloud login: non-interactive terminal; use --api-key or set BEACON_API_KEY")
 		}
 	}
 
@@ -82,12 +81,12 @@ func runCloudLogin(cmd *cobra.Command, args []string) {
 	}
 
 	if err := identity.WriteCloudLogin(apiKey, name); err != nil {
-		log.Fatalf("beacon cloud login: %v", err)
+		logger.Fatalf("beacon cloud login: %v", err)
 	}
 	p, err := identity.UserConfigPath()
 	if err != nil {
-		log.Printf("[Beacon] Wrote ~/.beacon/config.yaml")
+		logger.Infof("Wrote ~/.beacon/config.yaml")
 		return
 	}
-	log.Printf("[Beacon] Wrote %s", p)
+	logger.Infof("Wrote %s", p)
 }

--- a/cmd/beacon/config_cmd.go
+++ b/cmd/beacon/config_cmd.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"beacon/internal/cloud"
@@ -19,7 +18,7 @@ func createConfigCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			base, err := config.BeaconHomeDir()
 			if err != nil {
-				log.Fatal(err)
+				logger.Fatalf("%v", err)
 			}
 			fmt.Printf("beacon_home: %s\n", base)
 			if v := os.Getenv("BEACON_HOME"); v != "" {
@@ -27,12 +26,12 @@ func createConfigCommand() *cobra.Command {
 			}
 			p, err := identity.UserConfigPath()
 			if err != nil {
-				log.Fatal(err)
+				logger.Fatalf("%v", err)
 			}
 			fmt.Printf("config_file: %s\n", p)
 			uc, err := identity.LoadUserConfig()
 			if err != nil {
-				log.Printf("error loading config: %v", err)
+				logger.Errorf("error loading config: %v", err)
 				return
 			}
 			if uc == nil {

--- a/cmd/beacon/logging.go
+++ b/cmd/beacon/logging.go
@@ -1,0 +1,5 @@
+package main
+
+import "beacon/internal/logging"
+
+var logger = logging.New("cli")

--- a/cmd/beacon/main.go
+++ b/cmd/beacon/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -78,15 +77,15 @@ Available services: deploy, monitor, master (cloud agent: systemctl --user resta
 
 		switch service {
 		case "deploy":
-			log.Println("[Beacon] Restarting deploy service...")
-			log.Println("[Beacon] Deploy service restart requested")
+			logger.Infof("Restarting deploy service...")
+			logger.Infof("Deploy service restart requested")
 		case "monitor":
-			log.Println("[Beacon] Restarting monitor service...")
-			log.Println("[Beacon] Monitor service restart requested")
+			logger.Infof("Restarting monitor service...")
+			logger.Infof("Monitor service restart requested")
 		case "master":
-			log.Println("[Beacon] Restart master: systemctl --user restart beacon-master.service")
+			logger.Infof("Restart master: systemctl --user restart beacon-master.service")
 		default:
-			log.Printf("[Beacon] Unknown service: %s. Available services: deploy, monitor, master\n", service)
+			logger.Infof("Unknown service: %s. Available services: deploy, monitor, master\n", service)
 			os.Exit(1)
 		}
 	},
@@ -106,7 +105,7 @@ and reporting configuration.`,
 
 		w := wizard.NewWizard(configPath, envPath)
 		if err := w.Run(); err != nil {
-			log.Fatalf("Wizard failed: %v", err)
+			logger.Fatalf("Wizard failed: %v", err)
 		}
 	},
 }
@@ -130,10 +129,10 @@ var templateAddCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cli, err := templates.NewCLI()
 		if err != nil {
-			log.Fatalf("Failed to initialize template CLI: %v", err)
+			logger.Fatalf("Failed to initialize template CLI: %v", err)
 		}
 		if err := cli.AddTemplate(); err != nil {
-			log.Fatalf("Failed to add template: %v", err)
+			logger.Fatalf("Failed to add template: %v", err)
 		}
 	},
 }
@@ -145,10 +144,10 @@ var templateListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cli, err := templates.NewCLI()
 		if err != nil {
-			log.Fatalf("Failed to initialize template CLI: %v", err)
+			logger.Fatalf("Failed to initialize template CLI: %v", err)
 		}
 		if err := cli.ListTemplates(); err != nil {
-			log.Fatalf("Failed to list templates: %v", err)
+			logger.Fatalf("Failed to list templates: %v", err)
 		}
 	},
 }
@@ -160,10 +159,10 @@ var templateRemoveCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cli, err := templates.NewCLI()
 		if err != nil {
-			log.Fatalf("Failed to initialize template CLI: %v", err)
+			logger.Fatalf("Failed to initialize template CLI: %v", err)
 		}
 		if err := cli.RemoveTemplate(); err != nil {
-			log.Fatalf("Failed to remove template: %v", err)
+			logger.Fatalf("Failed to remove template: %v", err)
 		}
 	},
 }
@@ -176,10 +175,10 @@ var templateShowCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cli, err := templates.NewCLI()
 		if err != nil {
-			log.Fatalf("Failed to initialize template CLI: %v", err)
+			logger.Fatalf("Failed to initialize template CLI: %v", err)
 		}
 		if err := cli.ShowTemplate(args[0]); err != nil {
-			log.Fatalf("Failed to show template: %v", err)
+			logger.Fatalf("Failed to show template: %v", err)
 		}
 	},
 }
@@ -191,10 +190,10 @@ var templateCheckCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cli, err := templates.NewCLI()
 		if err != nil {
-			log.Fatalf("Failed to initialize template CLI: %v", err)
+			logger.Fatalf("Failed to initialize template CLI: %v", err)
 		}
 		if err := cli.CheckChanges(); err != nil {
-			log.Fatalf("Failed to check template changes: %v", err)
+			logger.Fatalf("Failed to check template changes: %v", err)
 		}
 	},
 }
@@ -206,7 +205,7 @@ var templateInitCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		templateDir := templates.GetDefaultTemplatePath()
 		if err := templates.CreateDefaultTemplates(templateDir); err != nil {
-			log.Fatalf("Failed to create default templates: %v", err)
+			logger.Fatalf("Failed to create default templates: %v", err)
 		}
 		fmt.Printf("✅ Default templates created in: %s\n", templateDir)
 		fmt.Println()
@@ -259,14 +258,14 @@ Environment: BEACON_DEVICE_NAME for default device name when --name is omitted.`
 		}
 
 		if err := identity.WriteUserLocalInit(name, metricsPort); err != nil {
-			log.Fatalf("beacon init: %v", err)
+			logger.Fatalf("beacon init: %v", err)
 		}
 		p, err := identity.UserConfigPath()
 		if err != nil {
-			log.Printf("[Beacon] Wrote ~/.beacon/config.yaml")
+			logger.Infof("Wrote ~/.beacon/config.yaml")
 			return
 		}
-		log.Printf("[Beacon] Wrote %s", p)
+		logger.Infof("Wrote %s", p)
 	},
 }
 
@@ -285,7 +284,7 @@ in the foreground (useful for systemd, Docker, or debugging).`,
 			// Re-exec ourselves with --foreground in a detached process
 			execPath, err := os.Executable()
 			if err != nil {
-				log.Fatalf("[Beacon] Cannot find executable: %v", err)
+				logger.Fatalf("Cannot find executable: %v", err)
 			}
 
 			// Build args: beacon master --foreground (pass through any other flags)
@@ -293,11 +292,11 @@ in the foreground (useful for systemd, Docker, or debugging).`,
 
 			logPath := filepath.Join(os.Getenv("HOME"), ".beacon", "master.log")
 			if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
-				log.Fatalf("[Beacon] Cannot create log dir: %v", err)
+				logger.Fatalf("Cannot create log dir: %v", err)
 			}
 			logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 			if err != nil {
-				log.Fatalf("[Beacon] Cannot open log file %s: %v", logPath, err)
+				logger.Fatalf("Cannot open log file %s: %v", logPath, err)
 			}
 
 			proc := &os.ProcAttr{
@@ -308,7 +307,7 @@ in the foreground (useful for systemd, Docker, or debugging).`,
 			}
 			p, err := os.StartProcess(execPath, append([]string{execPath}, childArgs...), proc)
 			if err != nil {
-				log.Fatalf("[Beacon] Failed to start background process: %v", err)
+				logger.Fatalf("Failed to start background process: %v", err)
 			}
 			_ = logFile.Close()
 			_ = p.Release()
@@ -379,11 +378,11 @@ var childAgentCmd = &cobra.Command{
 
 		c, err := child.New(cfg)
 		if err != nil {
-			log.Fatalf("[Beacon agent] Failed to initialize: %v", err)
+			logger.Fatalf("agent:Failed to initialize: %v", err)
 		}
 
 		if err := c.Run(); err != nil {
-			log.Fatalf("[Beacon agent] Failed: %v", err)
+			logger.Fatalf("agent:Failed: %v", err)
 		}
 	},
 }
@@ -475,7 +474,7 @@ or http for network access (requires --token-env for auth).`,
 				TokenEnv:  tokenEnv,
 			}
 			if err := mcp.RunServe(ctx, opts); err != nil {
-				log.Fatalf("MCP server: %v", err)
+				logger.Fatalf("MCP server: %v", err)
 			}
 		},
 	}
@@ -488,7 +487,7 @@ or http for network access (requires --token-env for auth).`,
 }
 
 func runDeploy() {
-	log.Println("[Beacon] Deploy agent starting...")
+	logger.Infof("Deploy agent starting...")
 
 	// Set up graceful shutdown
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -510,7 +509,7 @@ func runDeploy() {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Println("[Beacon] Shutdown signal received, stopping...")
+			logger.Infof("Shutdown signal received, stopping...")
 			return
 		case <-ticker.C:
 			deploy.CheckForNewTag(cfg, status)

--- a/cmd/beacon/tunnel.go
+++ b/cmd/beacon/tunnel.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -45,7 +44,7 @@ The tunnel connects automatically when the master agent starts.`,
 		Aliases: []string{"rm"},
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := identity.RemoveTunnel(args[0]); err != nil {
-				log.Fatalf("beacon tunnel remove: %v", err)
+				logger.Fatalf("beacon tunnel remove: %v", err)
 			}
 			fmt.Printf("Removed tunnel %q\n", args[0])
 		},
@@ -64,7 +63,7 @@ The tunnel connects automatically when the master agent starts.`,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := identity.SetTunnelEnabled(args[0], true); err != nil {
-				log.Fatalf("beacon tunnel enable: %v", err)
+				logger.Fatalf("beacon tunnel enable: %v", err)
 			}
 			fmt.Printf("Enabled tunnel %q\n", args[0])
 		},
@@ -76,7 +75,7 @@ The tunnel connects automatically when the master agent starts.`,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := identity.SetTunnelEnabled(args[0], false); err != nil {
-				log.Fatalf("beacon tunnel disable: %v", err)
+				logger.Fatalf("beacon tunnel disable: %v", err)
 			}
 			fmt.Printf("Disabled tunnel %q\n", args[0])
 		},
@@ -91,7 +90,7 @@ func runTunnelAdd(cmd *cobra.Command, args []string) {
 	port, _ := cmd.Flags().GetInt("port")
 
 	if err := identity.AppendTunnelIfMissing(id, port); err != nil {
-		log.Fatalf("beacon tunnel add: %v", err)
+		logger.Fatalf("beacon tunnel add: %v", err)
 	}
 	fmt.Printf("Added tunnel %q -> localhost:%d\n", id, port)
 
@@ -114,7 +113,7 @@ func runTunnelAdd(cmd *cobra.Command, args []string) {
 func runTunnelList(cmd *cobra.Command, args []string) {
 	cfg, err := identity.LoadUserConfig()
 	if err != nil {
-		log.Fatalf("beacon tunnel list: %v", err)
+		logger.Fatalf("beacon tunnel list: %v", err)
 	}
 	if cfg == nil || len(cfg.Tunnels) == 0 {
 		fmt.Println("No tunnels configured.")

--- a/internal/alerting/alert.go
+++ b/internal/alerting/alert.go
@@ -2,10 +2,13 @@ package alerting
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"time"
+
+	"beacon/internal/logging"
 )
+
+var logger = logging.New("alerting")
 
 // AlertSeverity represents the severity level of an alert
 type AlertSeverity string
@@ -115,7 +118,7 @@ func (sam *SimpleAlertManager) ProcessAlert(context AlertContext) error {
 	sam.mu.RUnlock()
 	if exists {
 		if time.Since(lastAlert) < 5*time.Minute { // 5 minute cooldown (consider making configurable)
-			log.Printf("[ALERT] Alert in cooldown for %s", cooldownKey)
+			logger.Infof("Alert in cooldown for %s", cooldownKey)
 			return nil
 		}
 	}
@@ -147,7 +150,7 @@ func (sam *SimpleAlertManager) sendAlert(routing *AlertRouting, context AlertCon
 	for _, channel := range routing.Channels {
 		err := sam.sendToChannel(channel, recipients, context)
 		if err != nil {
-			log.Printf("[ALERT] Failed to send via %s: %v", channel, err)
+			logger.Infof("Failed to send via %s: %v", channel, err)
 			// collect the last error; continue other channels
 			sendErr = err
 		}

--- a/internal/alerting/cli.go
+++ b/internal/alerting/cli.go
@@ -2,7 +2,6 @@ package alerting
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -65,11 +64,11 @@ func createSimpleInitCommand(cli *SimpleAlertingCLI) *cobra.Command {
 		Long:  `Create a simple alert routing configuration file with sensible defaults for a specific project.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if projectName == "" {
-				log.Fatalf("Project name is required. Use --project flag")
+				logger.Fatalf("Project name is required. Use --project flag")
 			}
 
 			if err := cli.InitSimpleConfig(projectName); err != nil {
-				log.Fatalf("Failed to initialize alert config: %v", err)
+				logger.Fatalf("Failed to initialize alert config: %v", err)
 			}
 			fmt.Println("✅ Simple alert routing configuration initialized!")
 			fmt.Printf("📁 Configuration file: %s\n", cli.configPath)
@@ -91,7 +90,7 @@ func createSimpleInitCommand(cli *SimpleAlertingCLI) *cobra.Command {
 	cmd.Flags().StringVarP(&projectName, "project", "p", "", "Project name (required)")
 	err := cmd.MarkFlagRequired("project")
 	if err != nil {
-		log.Fatalf("Failed to mark flag required: %v", err)
+		logger.Fatalf("Failed to mark flag required: %v", err)
 	}
 	return cmd
 }
@@ -103,7 +102,7 @@ func createSimpleStatusCommand(cli *SimpleAlertingCLI) *cobra.Command {
 		Long:  `Display all active alerts and their current status.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.ShowSimpleStatus(); err != nil {
-				log.Fatalf("Failed to show status: %v", err)
+				logger.Fatalf("Failed to show status: %v", err)
 			}
 		},
 	}
@@ -123,7 +122,7 @@ func createSimpleAcknowledgeCommand(cli *SimpleAlertingCLI) *cobra.Command {
 			}
 
 			if err := cli.AcknowledgeSimpleAlert(alertID, acknowledgedBy); err != nil {
-				log.Fatalf("Failed to acknowledge alert: %v", err)
+				logger.Fatalf("Failed to acknowledge alert: %v", err)
 			}
 			fmt.Printf("✅ Alert %s acknowledged by %s\n", alertID, acknowledgedBy)
 		},
@@ -139,7 +138,7 @@ func createSimpleResolveCommand(cli *SimpleAlertingCLI) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			alertID := args[0]
 			if err := cli.ResolveSimpleAlert(alertID); err != nil {
-				log.Fatalf("Failed to resolve alert: %v", err)
+				logger.Fatalf("Failed to resolve alert: %v", err)
 			}
 			fmt.Printf("✅ Alert %s resolved\n", alertID)
 		},
@@ -153,7 +152,7 @@ func createSimpleTestCommand(cli *SimpleAlertingCLI) *cobra.Command {
 		Long:  `Test the simple alert routing system with sample alerts.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cli.TestSimpleRouting(); err != nil {
-				log.Fatalf("Failed to test routing: %v", err)
+				logger.Fatalf("Failed to test routing: %v", err)
 			}
 		},
 	}

--- a/internal/child/child.go
+++ b/internal/child/child.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -21,6 +20,7 @@ import (
 
 	"beacon/internal/config"
 	"beacon/internal/ipc"
+	"beacon/internal/logging"
 	"beacon/internal/monitor"
 	"beacon/internal/state"
 )
@@ -43,12 +43,26 @@ type Child struct {
 	monitorCfg *monitor.Config
 	ipcWriter  *ipc.Writer
 	startedAt  time.Time
+	log        *logging.Logger
 
 	results    map[string]*checkResult
 	resultsMux sync.RWMutex
 
 	ctx    context.Context
 	cancel context.CancelFunc
+}
+
+// logger returns c.log or a fallback logger if unset (e.g. when tests construct Child directly).
+func (c *Child) logger() *logging.Logger {
+	if c.log != nil {
+		return c.log
+	}
+	name := "child"
+	if c.cfg != nil && c.cfg.ProjectID != "" {
+		name = c.cfg.ProjectID
+	}
+	c.log = logging.New(name)
+	return c.log
 }
 
 type checkResult struct {
@@ -144,6 +158,7 @@ func New(cfg *Config) (*Child, error) {
 		monitorCfg: monitorCfg,
 		ipcWriter:  ipcWriter,
 		startedAt:  time.Now(),
+		log:        logging.New(cfg.ProjectID),
 		results:    make(map[string]*checkResult),
 		ctx:        ctx,
 		cancel:     cancel,
@@ -152,9 +167,9 @@ func New(cfg *Config) (*Child, error) {
 
 // Run starts the child agent and blocks until shutdown.
 func (c *Child) Run() error {
-	log.Printf("[Beacon child] Starting for project: %s", c.cfg.ProjectID)
-	log.Printf("[Beacon child] Config: %s", c.cfg.ConfigPath)
-	log.Printf("[Beacon child] IPC dir: %s", c.cfg.IPCDir)
+	c.logger().Infof("Starting for project: %s", c.cfg.ProjectID)
+	c.logger().Infof("Config: %s", c.cfg.ConfigPath)
+	c.logger().Infof("IPC dir: %s", c.cfg.IPCDir)
 
 	// Set up signal handling
 	sigChan := make(chan os.Signal, 1)
@@ -194,12 +209,12 @@ func (c *Child) Run() error {
 
 	// Wait for shutdown signal
 	<-sigChan
-	log.Printf("[Beacon child] Shutdown signal received, stopping...")
+	c.logger().Infof("Shutdown signal received, stopping...")
 
 	c.cancel()
 	wg.Wait()
 
-	log.Printf("[Beacon child] Stopped")
+	c.logger().Infof("Stopped")
 	return nil
 }
 
@@ -248,7 +263,7 @@ func (c *Child) executeCheck(check monitor.CheckConfig) {
 	if !result.Passed {
 		status = "failed"
 	}
-	log.Printf("[Beacon child] Check %s (%s): %s (%dms)", check.Name, check.Type, status, result.LatencyMs)
+	c.logger().Infof("Check %s (%s): %s (%dms)", check.Name, check.Type, status, result.LatencyMs)
 }
 
 func (c *Child) executeHTTPCheck(check monitor.CheckConfig) checkResult {
@@ -395,7 +410,7 @@ func (c *Child) writeHealthReport() {
 	}
 
 	if err := c.ipcWriter.WriteHealth(report); err != nil {
-		log.Printf("[Beacon child] Failed to write health report: %v", err)
+		c.logger().Infof("Failed to write health report: %v", err)
 	}
 }
 
@@ -418,18 +433,18 @@ func (c *Child) runCommandPollLoop() {
 func (c *Child) checkForCommand() {
 	cmd, err := c.ipcWriter.ReadCommand()
 	if err != nil {
-		log.Printf("[Beacon child] Failed to read command: %v", err)
+		c.logger().Infof("Failed to read command: %v", err)
 		return
 	}
 	if cmd == nil {
 		return // No command
 	}
 
-	log.Printf("[Beacon child] Received command: %s (id=%s)", cmd.Action, cmd.ID)
+	c.logger().Infof("Received command: %s (id=%s)", cmd.Action, cmd.ID)
 	result := c.executeCommand(cmd)
 
 	if err := c.ipcWriter.WriteCommandResult(result); err != nil {
-		log.Printf("[Beacon child] Failed to write command result: %v", err)
+		c.logger().Infof("Failed to write command result: %v", err)
 	}
 }
 
@@ -468,7 +483,7 @@ func (c *Child) executeCommand(cmd *ipc.Command) *ipc.CommandResult {
 		result.Message = fmt.Sprintf("Unknown action: %s", cmd.Action)
 	}
 
-	log.Printf("[Beacon child] Command %s completed: %s - %s", cmd.ID, result.Status, result.Message)
+	c.logger().Infof("Command %s completed: %s - %s", cmd.ID, result.Status, result.Message)
 	return result
 }
 

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +35,7 @@ func CheckForNewGitTag(cfg *config.Config, status *state.Status) {
 	// Get Git token from key manager if token name is specified
 	gitToken, err := getGitToken(cfg)
 	if err != nil {
-		log.Printf("[Beacon] Failed to get Git token: %v", err)
+		logger.Infof("Failed to get Git token: %v", err)
 		return
 	}
 
@@ -48,12 +47,12 @@ func CheckForNewGitTag(cfg *config.Config, status *state.Status) {
 	// Check if we need to do initial deployment
 	shouldDeploy := false
 	if stat, err := os.Stat(cfg.LocalPath); os.IsNotExist(err) {
-		log.Println("[Beacon] Local path does not exist. Cloning repository...")
+		logger.Infof("Local path does not exist. Cloning repository...")
 		shouldDeploy = true
 	} else if err == nil && stat.IsDir() {
 		entries, _ := os.ReadDir(cfg.LocalPath)
 		if len(entries) == 0 {
-			log.Println("[Beacon] Local path is empty. Cloning repository...")
+			logger.Infof("Local path is empty. Cloning repository...")
 			shouldDeploy = true
 		}
 	}
@@ -62,10 +61,10 @@ func CheckForNewGitTag(cfg *config.Config, status *state.Status) {
 		// Clone default branch for initial deployment
 		err := Deploy(cfg, "", status)
 		if err != nil {
-			log.Printf("[Beacon] Error during initial deployment: %v\n", err)
+			logger.Infof("Error during initial deployment: %v\n", err)
 			return
 		}
-		log.Printf("[Beacon] Repository cloned to %s.\n", cfg.LocalPath)
+		logger.Infof("Repository cloned to %s.\n", cfg.LocalPath)
 		return
 	}
 
@@ -75,27 +74,27 @@ func CheckForNewGitTag(cfg *config.Config, status *state.Status) {
 		return
 	}
 
-	log.Printf("[Beacon] New tag found: %s (prev: %s)\n", latestTag, lastTag)
+	logger.Infof("New tag found: %s (prev: %s)\n", latestTag, lastTag)
 	if err := Deploy(cfg, latestTag, status); err != nil {
-		log.Printf("[Beacon] Error deploying: %v\n", err)
+		logger.Infof("Error deploying: %v\n", err)
 	}
 }
 
 func Deploy(cfg *config.Config, tag string, status *state.Status) error {
 	if tag == "" {
-		log.Printf("[Beacon] Deploying default branch...\n")
+		logger.Infof("Deploying default branch...\n")
 	} else {
-		log.Printf("[Beacon] Deploying tag %s...\n", tag)
+		logger.Infof("Deploying tag %s...\n", tag)
 	}
 
 	if err := os.RemoveAll(cfg.LocalPath); err != nil {
-		log.Printf("[Beacon] Error removing local path %s: %v\n", cfg.LocalPath, err)
+		logger.Infof("Error removing local path %s: %v\n", cfg.LocalPath, err)
 		return err
 	}
 
 	parentDir := filepath.Dir(cfg.LocalPath)
 	if err := os.MkdirAll(parentDir, 0755); err != nil {
-		log.Printf("[Beacon] Error creating parent directory %s: %v\n", parentDir, err)
+		logger.Infof("Error creating parent directory %s: %v\n", parentDir, err)
 		return err
 	}
 
@@ -119,25 +118,25 @@ func Deploy(cfg *config.Config, tag string, status *state.Status) error {
 	cloneCmd.Stderr = &stderr
 
 	if err := cloneCmd.Run(); err != nil {
-		log.Printf("[Beacon] Error cloning repository: %v\n", err)
-		log.Printf("[Beacon] Git error output: %s\n", stderr.String())
+		logger.Infof("Error cloning repository: %v\n", err)
+		logger.Infof("Git error output: %s\n", stderr.String())
 		return err
 	}
 
 	// Execute deploy command if specified
 	if cfg.DeployCommand != "" {
-		log.Printf("[Beacon] Executing deploy command: %s\n", cfg.DeployCommand)
+		logger.Infof("Executing deploy command: %s\n", cfg.DeployCommand)
 
 		// Build the command with secure environment file sourcing
 		var command string
 		if cfg.SecureEnvPath != "" {
 			// Check if secure env file exists
 			if _, err := os.Stat(cfg.SecureEnvPath); err == nil {
-				log.Printf("[Beacon] Sourcing secure environment file: %s\n", cfg.SecureEnvPath)
+				logger.Infof("Sourcing secure environment file: %s\n", cfg.SecureEnvPath)
 				command = fmt.Sprintf("set -a && . %s && set +a && %s", cfg.SecureEnvPath, cfg.DeployCommand)
 			} else {
-				log.Printf("[Beacon] Warning: Secure environment file not found: %s\n", cfg.SecureEnvPath)
-				log.Printf("[Beacon] Running deploy command without secure environment\n")
+				logger.Infof("Warning: Secure environment file not found: %s\n", cfg.SecureEnvPath)
+				logger.Infof("Running deploy command without secure environment\n")
 				command = cfg.DeployCommand
 			}
 		} else {
@@ -151,11 +150,11 @@ func Deploy(cfg *config.Config, tag string, status *state.Status) error {
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
-			log.Printf("[Beacon] Deploy command failed: %v\n", err)
+			logger.Infof("Deploy command failed: %v\n", err)
 			return err
 		}
 
-		log.Printf("[Beacon] Deploy command completed successfully\n")
+		logger.Infof("Deploy command completed successfully\n")
 	}
 
 	// Store the tag (or "default" for default branch)
@@ -166,9 +165,9 @@ func Deploy(cfg *config.Config, tag string, status *state.Status) error {
 	status.Set(tagToStore, time.Now())
 
 	if tag == "" {
-		log.Printf("[Beacon] Deployment of default branch complete.\n")
+		logger.Infof("Deployment of default branch complete.\n")
 	} else {
-		log.Printf("[Beacon] Deployment of tag %s complete.\n", tag)
+		logger.Infof("Deployment of tag %s complete.\n", tag)
 	}
 	return nil
 }
@@ -176,7 +175,7 @@ func Deploy(cfg *config.Config, tag string, status *state.Status) error {
 func getLatestTagFromRepo(cfg *config.Config) string {
 	// Check if repository exists
 	if _, err := os.Stat(cfg.LocalPath); os.IsNotExist(err) {
-		log.Printf("[Beacon] Repository path does not exist: %s\n", cfg.LocalPath)
+		logger.Infof("Repository path does not exist: %s\n", cfg.LocalPath)
 		return ""
 	}
 
@@ -184,7 +183,7 @@ func getLatestTagFromRepo(cfg *config.Config) string {
 	fetchCmd := exec.Command("git", "fetch", "--tags")
 	fetchCmd.Dir = cfg.LocalPath
 	if err := fetchCmd.Run(); err != nil {
-		log.Printf("[Beacon] Error fetching tags: %v\n", err)
+		logger.Infof("Error fetching tags: %v\n", err)
 		return ""
 	}
 
@@ -193,7 +192,7 @@ func getLatestTagFromRepo(cfg *config.Config) string {
 	forEachCmd.Dir = cfg.LocalPath
 	output, err := forEachCmd.Output()
 	if err != nil {
-		log.Printf("[Beacon] Error getting latest tag: %v\n", err)
+		logger.Infof("Error getting latest tag: %v\n", err)
 		return ""
 	}
 

--- a/internal/deploy/docker.go
+++ b/internal/deploy/docker.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -63,7 +62,7 @@ func NewDockerRegistryClient(imgCfg *config.DockerImageConfig) *DockerRegistryCl
 // CheckForNewImageTag polls all Docker images for new tags
 func CheckForNewImageTag(cfg *config.Config, status *state.Status) {
 	if len(cfg.DockerImages) == 0 {
-		log.Println("[Beacon] No Docker images configured")
+		logger.Infof("No Docker images configured")
 		return
 	}
 
@@ -90,19 +89,19 @@ func CheckForNewImageTag(cfg *config.Config, status *state.Status) {
 		// Check if we need to do initial deployment
 		shouldDeploy := false
 		if lastTag == "" {
-			log.Printf("[Beacon] No previous tag found for image %s. Performing initial deployment...\n", imgCfg.Image)
+			logger.Infof("No previous tag found for image %s. Performing initial deployment...\n", imgCfg.Image)
 			shouldDeploy = true
 		}
 
 		// Get latest tag from registry
 		latestTag, err := client.getLatestTag()
 		if err != nil {
-			log.Printf("[Beacon] Error getting latest tag from registry for %s: %v\n", imgCfg.Image, err)
+			logger.Infof("Error getting latest tag from registry for %s: %v\n", imgCfg.Image, err)
 			continue
 		}
 
 		if latestTag == "" {
-			log.Printf("[Beacon] No tags found for image %s\n", imgCfg.Image)
+			logger.Infof("No tags found for image %s\n", imgCfg.Image)
 			continue
 		}
 
@@ -112,14 +111,14 @@ func CheckForNewImageTag(cfg *config.Config, status *state.Status) {
 		}
 
 		if shouldDeploy {
-			log.Printf("[Beacon] Initial deployment for image %s with tag: %s\n", imgCfg.Image, latestTag)
+			logger.Infof("Initial deployment for image %s with tag: %s\n", imgCfg.Image, latestTag)
 		} else {
-			log.Printf("[Beacon] New tag found for image %s: %s (prev: %s)\n", imgCfg.Image, latestTag, lastTag)
+			logger.Infof("New tag found for image %s: %s (prev: %s)\n", imgCfg.Image, latestTag, lastTag)
 		}
 
 		// Deploy the new image
 		if err := DeployDockerImage(&imgCfg, cfg, latestTag, imageStatus); err != nil {
-			log.Printf("[Beacon] Error deploying Docker image %s: %v\n", imgCfg.Image, err)
+			logger.Infof("Error deploying Docker image %s: %v\n", imgCfg.Image, err)
 		}
 	}
 }
@@ -309,7 +308,7 @@ func (c *DockerRegistryClient) getFullImageName() string {
 func DeployDockerImage(imgCfg *config.DockerImageConfig, cfg *config.Config, tag string, status *state.Status) error {
 	client := NewDockerRegistryClient(imgCfg)
 
-	log.Printf("[Beacon] Deploying Docker image %s:%s...\n", client.getFullImageName(), tag)
+	logger.Infof("Deploying Docker image %s:%s...\n", client.getFullImageName(), tag)
 
 	// Pull the Docker image
 	fullImageName := fmt.Sprintf("%s:%s", client.getFullImageName(), tag)
@@ -325,16 +324,16 @@ func DeployDockerImage(imgCfg *config.DockerImageConfig, cfg *config.Config, tag
 
 	// Execute deploy command if specified
 	if deployCommand != "" {
-		log.Printf("[Beacon] Executing deploy command: %s\n", deployCommand)
+		logger.Infof("Executing deploy command: %s\n", deployCommand)
 
 		// Build the command with secure environment file sourcing
 		var command string
 		if cfg.SecureEnvPath != "" {
 			if _, err := os.Stat(cfg.SecureEnvPath); err == nil {
-				log.Printf("[Beacon] Sourcing secure environment file: %s\n", cfg.SecureEnvPath)
+				logger.Infof("Sourcing secure environment file: %s\n", cfg.SecureEnvPath)
 				command = fmt.Sprintf("set -a && . %s && set +a && %s", cfg.SecureEnvPath, deployCommand)
 			} else {
-				log.Printf("[Beacon] Warning: Secure environment file not found: %s\n", cfg.SecureEnvPath)
+				logger.Infof("Warning: Secure environment file not found: %s\n", cfg.SecureEnvPath)
 				command = deployCommand
 			}
 		} else {
@@ -363,7 +362,7 @@ func DeployDockerImage(imgCfg *config.DockerImageConfig, cfg *config.Config, tag
 
 				// Verify docker-compose file exists
 				if _, err := os.Stat(composePath); os.IsNotExist(err) {
-					log.Printf("[Beacon] Warning: Docker Compose file not found: %s\n", composePath)
+					logger.Infof("Warning: Docker Compose file not found: %s\n", composePath)
 				}
 			}
 
@@ -391,23 +390,23 @@ func DeployDockerImage(imgCfg *config.DockerImageConfig, cfg *config.Config, tag
 		cmd.Stderr = os.Stderr
 
 		if err := cmd.Run(); err != nil {
-			log.Printf("[Beacon] Deploy command failed: %v\n", err)
+			logger.Infof("Deploy command failed: %v\n", err)
 			return err
 		}
 
-		log.Printf("[Beacon] Deploy command completed successfully\n")
+		logger.Infof("Deploy command completed successfully\n")
 	}
 
 	// Store the tag
 	status.Set(tag, time.Now())
 
-	log.Printf("[Beacon] Deployment of Docker image %s:%s complete.\n", client.getFullImageName(), tag)
+	logger.Infof("Deployment of Docker image %s:%s complete.\n", client.getFullImageName(), tag)
 	return nil
 }
 
 // pullDockerImage pulls a Docker image from the registry
 func pullDockerImage(imageName string, client *DockerRegistryClient) error {
-	log.Printf("[Beacon] Pulling Docker image: %s\n", imageName)
+	logger.Infof("Pulling Docker image: %s\n", imageName)
 
 	// Build docker pull command
 	cmd := exec.Command("docker", "pull", imageName)
@@ -418,7 +417,7 @@ func pullDockerImage(imageName string, client *DockerRegistryClient) error {
 		loginCmd := exec.Command("docker", "login", "-u", client.username, "-p", client.password, client.registry)
 		loginCmd.Stdin = strings.NewReader(client.password)
 		if err := loginCmd.Run(); err != nil {
-			log.Printf("[Beacon] Warning: Docker login failed, trying pull without explicit login: %v\n", err)
+			logger.Infof("Warning: Docker login failed, trying pull without explicit login: %v\n", err)
 		}
 	}
 
@@ -429,7 +428,7 @@ func pullDockerImage(imageName string, client *DockerRegistryClient) error {
 		return fmt.Errorf("docker pull failed: %w", err)
 	}
 
-	log.Printf("[Beacon] Successfully pulled Docker image: %s\n", imageName)
+	logger.Infof("Successfully pulled Docker image: %s\n", imageName)
 	return nil
 }
 

--- a/internal/deploy/logging.go
+++ b/internal/deploy/logging.go
@@ -1,0 +1,5 @@
+package deploy
+
+import "beacon/internal/logging"
+
+var logger = logging.New("deploy")

--- a/internal/identity/userconfig.go
+++ b/internal/identity/userconfig.go
@@ -23,6 +23,7 @@ type UserConfig struct {
 	DeviceID              string          `yaml:"device_id,omitempty"`
 	MetricsPort           int             `yaml:"metrics_port,omitempty"`
 	MetricsListenAddr     string          `yaml:"metrics_listen_addr,omitempty"` // default "127.0.0.1"; set "0.0.0.0" for Docker
+	LogLevel              string          `yaml:"log_level,omitempty"`           // debug|info|warn|error; default "info"
 	Projects              []ProjectConfig `yaml:"projects,omitempty"`
 	Tunnels               []TunnelConfig  `yaml:"tunnels,omitempty"`
 	// SystemMetrics configures host metrics sent with cloud heartbeats (~/.beacon/config.yaml only).

--- a/internal/k8sobserver/informers.go
+++ b/internal/k8sobserver/informers.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"log"
 	"sync"
 	"time"
 
 	"beacon/internal/k8sobserver/sources"
+	"beacon/internal/logging"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +23,8 @@ const (
 	resyncPeriod = 15 * time.Minute
 	indexByOwner = "by-owner"
 )
+
+var logger = logging.New("k8sobserver")
 
 // Observer implements sources.Source for Kubernetes (read-only).
 type Observer struct {
@@ -286,7 +288,7 @@ func (o *Observer) onPodChange(indexer cache.Indexer, pod *corev1.Pod) {
 		key := pod.Namespace + "/" + string(ref.UID)
 		objs, err := indexer.ByIndex(indexByOwner, key)
 		if err != nil {
-			log.Printf("[Beacon] k8s index lookup: %v", err)
+			logger.Warnf("k8s index lookup: %v", err)
 			return
 		}
 		id := workloadID(o.cfg.ClusterID, pod.Namespace, ref.Kind, ref.Name)
@@ -378,7 +380,7 @@ func (o *Observer) emitWorkload(id string) {
 	}
 	obs := w.toObservation()
 	if err := o.sink.RecordObservation(obs); err != nil {
-		log.Printf("[Beacon] k8s sink RecordObservation: %v", err)
+		logger.Warnf("k8s sink RecordObservation: %v", err)
 	}
 	if w.InDrift {
 		_ = o.sink.RecordEvent(EventFromSnapshot("drift_detected", "drift", w, map[string]interface{}{"reasons": w.DriftReasons}))

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,157 @@
+// Package logging provides a thin logger with per-component prefixes.
+//
+// Every logger is created with a free-form name that becomes the prefix:
+//
+//	logging.New("master")            -> [Beacon master] ...
+//	logging.New(cfg.ProjectID)       -> [Beacon home-assistant] ...
+//	logging.New("tunnel " + id)      -> [Beacon tunnel abc123] ...
+//
+// Output format matches the old stdlib log: "YYYY/MM/DD HH:MM:SS [Beacon name] message".
+// Levels are filtered globally via SetLevel; BEACON_LOG_LEVEL env var overrides any
+// programmatic setting.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Level represents a log severity level.
+type Level int32
+
+const (
+	LevelDebug Level = iota
+	LevelInfo
+	LevelWarn
+	LevelError
+)
+
+var (
+	currentLevel atomic.Int32 // stores Level
+	envOverride  bool         // true if BEACON_LOG_LEVEL was set at startup
+
+	outMu sync.Mutex
+	out   io.Writer = os.Stderr
+)
+
+func init() {
+	currentLevel.Store(int32(LevelInfo))
+	if v := strings.TrimSpace(os.Getenv("BEACON_LOG_LEVEL")); v != "" {
+		if lvl, ok := parseLevel(v); ok {
+			currentLevel.Store(int32(lvl))
+			envOverride = true
+		}
+	}
+}
+
+// SetLevel sets the global minimum log level. Values: "debug", "info", "warn", "error".
+// A value of "" or an unrecognized level is ignored. BEACON_LOG_LEVEL env var takes
+// precedence — if it was set at process start, SetLevel is a no-op.
+func SetLevel(level string) {
+	if envOverride {
+		return
+	}
+	if lvl, ok := parseLevel(level); ok {
+		currentLevel.Store(int32(lvl))
+	}
+}
+
+// SetOutput redirects log output. Used by tests.
+func SetOutput(w io.Writer) {
+	outMu.Lock()
+	defer outMu.Unlock()
+	if w == nil {
+		out = os.Stderr
+	} else {
+		out = w
+	}
+}
+
+func parseLevel(s string) (Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return LevelDebug, true
+	case "info":
+		return LevelInfo, true
+	case "warn", "warning":
+		return LevelWarn, true
+	case "error", "err":
+		return LevelError, true
+	}
+	return 0, false
+}
+
+// Logger carries a baked-in prefix and writes to the package output.
+type Logger struct {
+	prefix string // e.g. "[Beacon master]"
+}
+
+// New creates a logger whose prefix is "[Beacon <name>]".
+// The name is free-form — callers pass whatever reads best for their component.
+func New(name string) *Logger {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return &Logger{prefix: "[Beacon]"}
+	}
+	return &Logger{prefix: "[Beacon " + name + "]"}
+}
+
+func (l *Logger) enabled(lvl Level) bool {
+	return int32(lvl) >= currentLevel.Load()
+}
+
+func (l *Logger) write(lvl Level, format string, args ...any) {
+	if !l.enabled(lvl) {
+		return
+	}
+	msg := format
+	if len(args) > 0 {
+		msg = fmt.Sprintf(format, args...)
+	}
+	ts := time.Now().Format("2006/01/02 15:04:05")
+	var line string
+	if lvl == LevelInfo {
+		line = fmt.Sprintf("%s %s %s\n", ts, l.prefix, msg)
+	} else {
+		line = fmt.Sprintf("%s %s %s: %s\n", ts, l.prefix, levelTag(lvl), msg)
+	}
+	outMu.Lock()
+	_, _ = io.WriteString(out, line)
+	outMu.Unlock()
+}
+
+func levelTag(lvl Level) string {
+	switch lvl {
+	case LevelDebug:
+		return "DEBUG"
+	case LevelWarn:
+		return "WARN"
+	case LevelError:
+		return "ERROR"
+	default:
+		return "INFO"
+	}
+}
+
+// Debugf logs at debug level.
+func (l *Logger) Debugf(format string, args ...any) { l.write(LevelDebug, format, args...) }
+
+// Infof logs at info level (the default).
+func (l *Logger) Infof(format string, args ...any) { l.write(LevelInfo, format, args...) }
+
+// Warnf logs at warn level.
+func (l *Logger) Warnf(format string, args ...any) { l.write(LevelWarn, format, args...) }
+
+// Errorf logs at error level.
+func (l *Logger) Errorf(format string, args ...any) { l.write(LevelError, format, args...) }
+
+// Fatalf logs at error level and then calls os.Exit(1).
+func (l *Logger) Fatalf(format string, args ...any) {
+	l.write(LevelError, format, args...)
+	os.Exit(1)
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -26,8 +26,8 @@ func TestPrefixFormat(t *testing.T) {
 	buf := captureOutput(t)
 
 	cases := []struct {
-		name   string
-		want   string
+		name string
+		want string
 	}{
 		{"master", "[Beacon master]"},
 		{"home-assistant", "[Beacon home-assistant]"},

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,125 @@
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// resetForTest restores default state between tests.
+func resetForTest(t *testing.T) {
+	t.Helper()
+	currentLevel.Store(int32(LevelInfo))
+	envOverride = false
+	SetOutput(nil)
+}
+
+func captureOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	SetOutput(buf)
+	return buf
+}
+
+func TestPrefixFormat(t *testing.T) {
+	resetForTest(t)
+	buf := captureOutput(t)
+
+	cases := []struct {
+		name   string
+		want   string
+	}{
+		{"master", "[Beacon master]"},
+		{"home-assistant", "[Beacon home-assistant]"},
+		{"tunnel abc123", "[Beacon tunnel abc123]"},
+		{"", "[Beacon]"},
+		{"  deploy  ", "[Beacon deploy]"},
+	}
+	for _, tc := range cases {
+		buf.Reset()
+		l := New(tc.name)
+		l.Infof("hello %s", "world")
+		got := buf.String()
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("New(%q).Infof: want prefix %q in output, got %q", tc.name, tc.want, got)
+		}
+		if !strings.Contains(got, "hello world") {
+			t.Errorf("New(%q).Infof: missing formatted message in output %q", tc.name, got)
+		}
+	}
+}
+
+func TestLevelFiltering(t *testing.T) {
+	resetForTest(t)
+	buf := captureOutput(t)
+	l := New("test")
+
+	// Default is info: debug suppressed, info/warn/error pass.
+	l.Debugf("debug1")
+	l.Infof("info1")
+	l.Warnf("warn1")
+	l.Errorf("error1")
+	out := buf.String()
+	if strings.Contains(out, "debug1") {
+		t.Errorf("debug should be filtered at info level, got %q", out)
+	}
+	for _, want := range []string{"info1", "warn1", "error1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output %q", want, out)
+		}
+	}
+
+	// Raise to warn: info also filtered.
+	buf.Reset()
+	SetLevel("warn")
+	l.Debugf("debug2")
+	l.Infof("info2")
+	l.Warnf("warn2")
+	out = buf.String()
+	if strings.Contains(out, "debug2") || strings.Contains(out, "info2") {
+		t.Errorf("debug/info should be filtered at warn level, got %q", out)
+	}
+	if !strings.Contains(out, "warn2") {
+		t.Errorf("warn should pass, got %q", out)
+	}
+}
+
+func TestEnvOverrideBlocksSetLevel(t *testing.T) {
+	resetForTest(t)
+	envOverride = true
+	currentLevel.Store(int32(LevelError))
+
+	SetLevel("debug") // should be ignored
+	if currentLevel.Load() != int32(LevelError) {
+		t.Errorf("env override should block SetLevel, level is %v", currentLevel.Load())
+	}
+}
+
+func TestLevelTagInOutput(t *testing.T) {
+	resetForTest(t)
+	buf := captureOutput(t)
+	l := New("x")
+	l.Warnf("careful")
+	l.Errorf("boom")
+	out := buf.String()
+	if !strings.Contains(out, "WARN: careful") {
+		t.Errorf("want WARN tag, got %q", out)
+	}
+	if !strings.Contains(out, "ERROR: boom") {
+		t.Errorf("want ERROR tag, got %q", out)
+	}
+}
+
+func TestInfoHasNoLevelTag(t *testing.T) {
+	resetForTest(t)
+	buf := captureOutput(t)
+	l := New("x")
+	l.Infof("plain")
+	out := buf.String()
+	if strings.Contains(out, "INFO:") {
+		t.Errorf("info lines should not carry a level tag, got %q", out)
+	}
+	if !strings.Contains(out, "[Beacon x] plain") {
+		t.Errorf("want formatted info line, got %q", out)
+	}
+}

--- a/internal/master/dispatcher.go
+++ b/internal/master/dispatcher.go
@@ -2,7 +2,6 @@ package master
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -75,7 +74,7 @@ func (d *CommandDispatcher) DispatchCommands(commands []HeartbeatCommand) {
 
 		reader, exists := readers[cmd.TargetProject]
 		if !exists {
-			log.Printf("[Beacon master] Command %s: project %s not found", cmd.ID, cmd.TargetProject)
+			logger.Infof("Command %s: project %s not found", cmd.ID, cmd.TargetProject)
 			d.recordResult(cmd.ID, ipc.ResultFailed, "Project not found: "+cmd.TargetProject)
 			continue
 		}
@@ -89,12 +88,12 @@ func (d *CommandDispatcher) DispatchCommands(commands []HeartbeatCommand) {
 		}
 
 		if err := reader.WriteCommand(ipcCmd); err != nil {
-			log.Printf("[Beacon master] Failed to dispatch command %s to %s: %v", cmd.ID, cmd.TargetProject, err)
+			logger.Infof("Failed to dispatch command %s to %s: %v", cmd.ID, cmd.TargetProject, err)
 			d.recordResult(cmd.ID, ipc.ResultFailed, "Failed to dispatch: "+err.Error())
 			continue
 		}
 
-		log.Printf("[Beacon master] Dispatched command %s (%s) to %s", cmd.ID, cmd.Action, cmd.TargetProject)
+		logger.Infof("Dispatched command %s (%s) to %s", cmd.ID, cmd.Action, cmd.TargetProject)
 	}
 }
 
@@ -158,14 +157,14 @@ func (d *CommandDispatcher) CollectResults() {
 	for projectID, reader := range readers {
 		result, err := reader.ReadCommandResult()
 		if err != nil {
-			log.Printf("[Beacon master] Error reading command result from %s: %v", projectID, err)
+			logger.Infof("Error reading command result from %s: %v", projectID, err)
 			continue
 		}
 		if result == nil {
 			continue // No result
 		}
 
-		log.Printf("[Beacon master] Collected result for command %s from %s: %s", result.CommandID, projectID, result.Status)
+		logger.Infof("Collected result for command %s from %s: %s", result.CommandID, projectID, result.Status)
 		d.recordResult(result.CommandID, result.Status, result.Message)
 	}
 }

--- a/internal/master/logging.go
+++ b/internal/master/logging.go
@@ -1,0 +1,8 @@
+package master
+
+import "beacon/internal/logging"
+
+// logger is the shared master-component logger. Its prefix is "[Beacon master]".
+// Sub-components that need a more specific prefix (e.g. tunnels with their own ID)
+// create their own logger directly.
+var logger = logging.New("master")

--- a/internal/master/process.go
+++ b/internal/master/process.go
@@ -3,7 +3,6 @@ package master
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,12 +62,12 @@ func NewProcessManager(ctx context.Context) (*ProcessManager, error) {
 func (pm *ProcessManager) SpawnAll(projects []identity.ProjectConfig) {
 	for _, project := range projects {
 		if !pm.isProjectEnabled(project) {
-			log.Printf("[Beacon master] Project %s is disabled, skipping", project.ID)
+			logger.Infof("Project %s is disabled, skipping", project.ID)
 			continue
 		}
 
 		if err := pm.Spawn(project); err != nil {
-			log.Printf("[Beacon master] Failed to start project %s: %v", project.ID, err)
+			logger.Infof("Failed to start project %s: %v", project.ID, err)
 		}
 	}
 }
@@ -119,7 +118,7 @@ func (pm *ProcessManager) Spawn(project identity.ProjectConfig) error {
 	pm.wg.Add(1)
 	go pm.watchChild(child)
 
-	log.Printf("[Beacon master] Started project %s (PID %d)", project.ID, child.Cmd.Process.Pid)
+	logger.Infof("Started project %s (PID %d)", project.ID, child.Cmd.Process.Pid)
 	return nil
 }
 
@@ -162,7 +161,7 @@ func (pm *ProcessManager) watchChild(child *ChildProcess) {
 		// Check if we're shutting down
 		select {
 		case <-pm.ctx.Done():
-			log.Printf("[Beacon master] Project %s exited during shutdown", child.ProjectID)
+			logger.Infof("Project %s exited during shutdown", child.ProjectID)
 			return
 		default:
 		}
@@ -172,13 +171,13 @@ func (pm *ProcessManager) watchChild(child *ChildProcess) {
 		if child.Cmd.ProcessState != nil {
 			exitCode = child.Cmd.ProcessState.ExitCode()
 		}
-		log.Printf("[Beacon master] Project %s exited (code=%d, err=%v)", child.ProjectID, exitCode, err)
+		logger.Infof("Project %s exited (code=%d, err=%v)", child.ProjectID, exitCode, err)
 
 		pm.mu.Lock()
 		child.Restarts++
 
 		if child.Restarts > maxRestarts {
-			log.Printf("[Beacon master] Project %s exceeded max restarts (%d), giving up", child.ProjectID, maxRestarts)
+			logger.Infof("Project %s exceeded max restarts (%d), giving up", child.ProjectID, maxRestarts)
 			child.Failed = true
 			pm.mu.Unlock()
 			return
@@ -191,7 +190,7 @@ func (pm *ProcessManager) watchChild(child *ChildProcess) {
 		}
 		pm.mu.Unlock()
 
-		log.Printf("[Beacon master] Restarting project %s in %v (attempt %d/%d)", child.ProjectID, backoff, child.Restarts, maxRestarts)
+		logger.Infof("Restarting project %s in %v (attempt %d/%d)", child.ProjectID, backoff, child.Restarts, maxRestarts)
 
 		// Wait for backoff
 		select {
@@ -203,12 +202,12 @@ func (pm *ProcessManager) watchChild(child *ChildProcess) {
 		// Respawn
 		pm.mu.Lock()
 		if err := pm.spawnChild(child); err != nil {
-			log.Printf("[Beacon master] Failed to restart project %s: %v", child.ProjectID, err)
+			logger.Infof("Failed to restart project %s: %v", child.ProjectID, err)
 			child.Failed = true
 			pm.mu.Unlock()
 			return
 		}
-		log.Printf("[Beacon master] Restarted project %s (PID %d)", child.ProjectID, child.Cmd.Process.Pid)
+		logger.Infof("Restarted project %s (PID %d)", child.ProjectID, child.Cmd.Process.Pid)
 		pm.mu.Unlock()
 
 		if pm.eventLog != nil {
@@ -224,7 +223,7 @@ func (pm *ProcessManager) watchChild(child *ChildProcess) {
 
 // Shutdown gracefully stops all child processes.
 func (pm *ProcessManager) Shutdown() {
-	log.Printf("[Beacon master] Stopping all projects...")
+	logger.Infof("Stopping all projects...")
 
 	// Cancel context to stop respawn attempts
 	pm.cancel()
@@ -240,7 +239,7 @@ func (pm *ProcessManager) Shutdown() {
 
 	// Send SIGTERM to all children
 	for _, child := range children {
-		log.Printf("[Beacon master] Stopping project %s (PID %d)", child.ProjectID, child.Cmd.Process.Pid)
+		logger.Infof("Stopping project %s (PID %d)", child.ProjectID, child.Cmd.Process.Pid)
 		_ = child.Cmd.Process.Signal(os.Interrupt)
 	}
 
@@ -253,9 +252,9 @@ func (pm *ProcessManager) Shutdown() {
 
 	select {
 	case <-done:
-		log.Printf("[Beacon master] All projects stopped gracefully")
+		logger.Infof("All projects stopped gracefully")
 	case <-time.After(shutdownWait):
-		log.Printf("[Beacon master] Timeout waiting for projects to stop, forcing shutdown")
+		logger.Infof("Timeout waiting for projects to stop, forcing shutdown")
 		for _, child := range children {
 			if child.Cmd.ProcessState == nil {
 				_ = child.Cmd.Process.Kill()

--- a/internal/master/run.go
+++ b/internal/master/run.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	"beacon/internal/identity"
+	"beacon/internal/logging"
 	"beacon/internal/tunnel"
 	"beacon/internal/version"
 )
@@ -113,8 +113,15 @@ func getOutboundIP() string {
 func Run(ctx context.Context) {
 	uc, err := identity.LoadUserConfig()
 	if err != nil {
-		log.Printf("[Beacon master] Failed to load config: %v", err)
+		logger.Infof("Failed to load config: %v", err)
 		uc = nil
+	}
+	if uc != nil && uc.LogLevel != "" {
+		logging.SetLevel(uc.LogLevel)
+		// Propagate to spawned children via env inheritance (only if env var not already set).
+		if os.Getenv("BEACON_LOG_LEVEL") == "" {
+			_ = os.Setenv("BEACON_LOG_LEVEL", uc.LogLevel)
+		}
 	}
 	interval := 60 * time.Second
 	if uc != nil {
@@ -123,7 +130,7 @@ func Run(ctx context.Context) {
 
 	pm, err := NewProcessManager(ctx)
 	if err != nil {
-		log.Printf("[Beacon master] Failed to create process manager: %v", err)
+		logger.Infof("Failed to create process manager: %v", err)
 	}
 
 	eventLog := NewEventLog()
@@ -147,7 +154,7 @@ func Run(ctx context.Context) {
 	startCacheRefresh(ctx, statusCache)
 
 	if pm != nil && uc != nil && len(uc.Projects) > 0 {
-		log.Printf("[Beacon master] Spawning %d project(s)...", len(uc.Projects))
+		logger.Infof("Spawning %d project(s)...", len(uc.Projects))
 		pm.SpawnAll(uc.Projects)
 	}
 
@@ -159,7 +166,7 @@ func Run(ctx context.Context) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	log.Printf("[Beacon master] Started (interval=%s)", interval)
+	logger.Infof("Started (interval=%s)", interval)
 
 	beat := &heartbeatLoop{
 		ctx:         ctx,
@@ -177,7 +184,7 @@ func Run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Printf("[Beacon master] Stopping")
+			logger.Infof("Stopping")
 			if tm != nil {
 				tm.Shutdown()
 			}
@@ -200,7 +207,7 @@ func startStatusServer(ctx context.Context, cache *StatusCache, port int, listen
 	}
 	go func() {
 		if err := srv.Start(ctx); err != nil && ctx.Err() == nil {
-			log.Printf("[Beacon master] Status server: %v", err)
+			logger.Infof("Status server: %v", err)
 		}
 	}()
 }
@@ -227,7 +234,7 @@ func initTunnelManager(ctx context.Context, uc *identity.UserConfig) *tunnel.Tun
 	}
 	tm, err := tunnel.NewTunnelManager(ctx)
 	if err != nil {
-		log.Printf("[Beacon master] Failed to create tunnel manager: %v", err)
+		logger.Infof("Failed to create tunnel manager: %v", err)
 		return nil
 	}
 	apiKey := strings.TrimSpace(uc.APIKey)
@@ -241,16 +248,16 @@ func initTunnelManager(ctx context.Context, uc *identity.UserConfig) *tunnel.Tun
 			continue
 		}
 		if started >= tunnel.MaxActiveTunnels {
-			log.Printf("[Beacon master] Tunnel %s skipped (limit: %d active tunnels)", t.ID, tunnel.MaxActiveTunnels)
+			logger.Infof("Tunnel %s skipped (limit: %d active tunnels)", t.ID, tunnel.MaxActiveTunnels)
 			continue
 		}
 		if err := tm.EnsureStarted(t, uc.EffectiveCloudAPIBase(), apiKey, deviceName); err != nil {
-			log.Printf("[Beacon master] Tunnel %s failed to start: %v", t.ID, err)
+			logger.Infof("Tunnel %s failed to start: %v", t.ID, err)
 		} else {
 			started++
 		}
 	}
-	log.Printf("[Beacon master] Tunnel manager started (%d/%d tunnel(s) active)", started, len(uc.Tunnels))
+	logger.Infof("Tunnel manager started (%d/%d tunnel(s) active)", started, len(uc.Tunnels))
 	return tm
 }
 
@@ -268,7 +275,7 @@ type heartbeatLoop struct {
 func (h *heartbeatLoop) tryBeat() {
 	uc, err := identity.LoadUserConfig()
 	if err != nil {
-		log.Printf("[Beacon master] Reload config: %v", err)
+		logger.Infof("Reload config: %v", err)
 		return
 	}
 	if uc == nil || !uc.CloudReportingEnabled {
@@ -286,7 +293,7 @@ func (h *heartbeatLoop) tryBeat() {
 	h.dispatcher.CollectResults()
 
 	if err := sendCloudHeartbeat(h.ctx, h, uc, name, h.pm, h.dispatcher, h.tm); err != nil {
-		log.Printf("[Beacon master] Heartbeat: %v", err)
+		logger.Infof("Heartbeat: %v", err)
 	} else {
 		h.statusCache.UpdateCloudSync()
 		h.eventLog.Append(Event{
@@ -330,10 +337,10 @@ func sendCloudHeartbeat(ctx context.Context, h *heartbeatLoop, cfg *identity.Use
 	}
 
 	if len(payload.Projects) > 0 {
-		log.Printf("[Beacon master] Heartbeat includes %d project(s)", len(payload.Projects))
+		logger.Infof("Heartbeat includes %d project(s)", len(payload.Projects))
 	}
 	if len(payload.CommandResults) > 0 {
-		log.Printf("[Beacon master] Heartbeat includes %d command result(s)", len(payload.CommandResults))
+		logger.Infof("Heartbeat includes %d command result(s)", len(payload.CommandResults))
 	}
 
 	body, err := json.Marshal(payload)
@@ -366,19 +373,19 @@ func sendCloudHeartbeat(ctx context.Context, h *heartbeatLoop, cfg *identity.Use
 	// Parse response
 	var hr heartbeatResponse
 	if err := json.Unmarshal(respBody, &hr); err != nil {
-		log.Printf("[Beacon master] Failed to parse heartbeat response: %v", err)
+		logger.Infof("Failed to parse heartbeat response: %v", err)
 	} else {
 		// Save device_id if changed
 		if hr.DeviceID != "" && cfg.DeviceID != hr.DeviceID {
 			cfg.DeviceID = hr.DeviceID
 			if err := cfg.Save(); err != nil {
-				log.Printf("[Beacon master] Could not save device_id: %v", err)
+				logger.Infof("Could not save device_id: %v", err)
 			}
 		}
 
 		// Dispatch any commands from the response
 		if dispatcher != nil && len(hr.Commands) > 0 {
-			log.Printf("[Beacon master] Received %d command(s) from server", len(hr.Commands))
+			logger.Infof("Received %d command(s) from server", len(hr.Commands))
 			dispatcher.DispatchCommands(hr.Commands)
 		}
 	}

--- a/internal/master/status_server.go
+++ b/internal/master/status_server.go
@@ -5,7 +5,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -55,7 +54,7 @@ func (s *StatusServer) Start(ctx context.Context) error {
 		return fmt.Errorf("status server bind %s: %w", addr, err)
 	}
 
-	log.Printf("[Beacon master] Dashboard: http://%s:%d  API: http://%s:%d/api/status", s.listenAddr, s.port, s.listenAddr, s.port)
+	logger.Infof("Dashboard: http://%s:%d  API: http://%s:%d/api/status", s.listenAddr, s.port, s.listenAddr, s.port)
 
 	go func() {
 		<-ctx.Done()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
 
 	"beacon/internal/config"
+	"beacon/internal/logging"
 	"beacon/internal/version"
 
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+var logger = logging.New("mcp")
 
 // InventoryInput has no args
 type InventoryInput struct{}
@@ -190,9 +192,9 @@ func runHTTP(ctx context.Context, opts ServeOptions) error {
 		_ = srv.Shutdown(context.Background())
 	}()
 
-	log.Printf("MCP server listening on http://%s", listen)
+	logger.Infof("MCP server listening on http://%s", listen)
 	if opts.TokenEnv != "" {
-		log.Printf("Bearer token required (from %s)", opts.TokenEnv)
+		logger.Infof("Bearer token required (from %s)", opts.TokenEnv)
 	}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return err

--- a/internal/monitor/log.go
+++ b/internal/monitor/log.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -161,13 +160,13 @@ func (lm *LogManager) loadLogPositions() {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			log.Printf("[Beacon] Failed to load log positions: %v", err)
+			logger.Infof("Failed to load log positions: %v", err)
 		}
 		return
 	}
 	var positions map[string]logCursor
 	if err := json.Unmarshal(data, &positions); err != nil {
-		log.Printf("[Beacon] Failed to parse log positions: %v", err)
+		logger.Infof("Failed to parse log positions: %v", err)
 		return
 	}
 	lm.logPositionsMux.Lock()
@@ -186,11 +185,11 @@ func (lm *LogManager) saveLogPositions() {
 	path := filepath.Join(lm.stateDir, logPositionsFilename)
 	data, err := json.MarshalIndent(positions, "", "  ")
 	if err != nil {
-		log.Printf("[Beacon] Failed to marshal log positions: %v", err)
+		logger.Infof("Failed to marshal log positions: %v", err)
 		return
 	}
 	if err := os.WriteFile(path, data, 0644); err != nil {
-		log.Printf("[Beacon] Failed to write log positions: %v", err)
+		logger.Infof("Failed to write log positions: %v", err)
 	}
 }
 
@@ -272,7 +271,7 @@ func (lm *LogManager) parseLogTimestamp(line string) (time.Time, string) {
 
 // StartLogCollection starts all configured log sources
 func (lm *LogManager) StartLogCollection(ctx context.Context) {
-	log.Printf("[Beacon] Starting log collection for %d sources", len(lm.config.LogSources))
+	logger.Infof("Starting log collection for %d sources", len(lm.config.LogSources))
 
 	lm.loadLogPositions()
 
@@ -336,7 +335,7 @@ func (lm *LogManager) StartLogCollection(ctx context.Context) {
 		case "command":
 			go lm.runCommandLogCollection(logCollector)
 		default:
-			log.Printf("[Beacon] Unknown log source type: %s", source.Type)
+			logger.Infof("Unknown log source type: %s", source.Type)
 		}
 	}
 }
@@ -434,11 +433,11 @@ func (lm *LogManager) FlushAndStop(ctx context.Context) {
 // runFileLogCollection handles file-based log collection
 func (lm *LogManager) runFileLogCollection(collector *LogCollector) {
 	source := collector.source
-	log.Printf("[Beacon] Starting file log collection: %s -> %s", source.Name, source.FilePath)
+	logger.Infof("Starting file log collection: %s -> %s", source.Name, source.FilePath)
 
 	// If user explicitly wants tail or we can't open the file directly, use tail
 	if source.UseTail || !lm.canAccessFileDirectly(source.FilePath) {
-		log.Printf("[Beacon] Using tail command for %s", source.FilePath)
+		logger.Infof("Using tail command for %s", source.FilePath)
 		lm.runFileLogCollectionWithTail(collector)
 		return
 	}
@@ -446,7 +445,7 @@ func (lm *LogManager) runFileLogCollection(collector *LogCollector) {
 	// Try direct file access
 	file, err := os.Open(source.FilePath)
 	if err != nil {
-		log.Printf("[Beacon] Cannot open file %s directly (%v), falling back to tail", source.FilePath, err)
+		logger.Infof("Cannot open file %s directly (%v), falling back to tail", source.FilePath, err)
 		lm.runFileLogCollectionWithTail(collector)
 		return
 	}
@@ -457,7 +456,7 @@ func (lm *LogManager) runFileLogCollection(collector *LogCollector) {
 	// Get initial file size and position
 	stat, err := file.Stat()
 	if err != nil {
-		log.Printf("[Beacon] Error getting file stats for %s: %v", source.FilePath, err)
+		logger.Infof("Error getting file stats for %s: %v", source.FilePath, err)
 		lm.runFileLogCollectionWithTail(collector)
 		return
 	}
@@ -471,7 +470,7 @@ func (lm *LogManager) runFileLogCollection(collector *LogCollector) {
 		}
 	}
 
-	log.Printf("[Beacon] Using direct file access for %s", source.FilePath)
+	logger.Infof("Using direct file access for %s", source.FilePath)
 	ticker := time.NewTicker(source.Interval)
 	defer ticker.Stop()
 
@@ -503,7 +502,7 @@ func (lm *LogManager) collectFileLogFromPosition(collector *LogCollector) []LogE
 	// Get current file size
 	stat, err := file.Stat()
 	if err != nil {
-		log.Printf("[Beacon] Error getting file stats for %s: %v", source.FilePath, err)
+		logger.Infof("Error getting file stats for %s: %v", source.FilePath, err)
 		return nil
 	}
 
@@ -511,7 +510,7 @@ func (lm *LogManager) collectFileLogFromPosition(collector *LogCollector) []LogE
 
 	// If file was truncated (log rotation), reset position
 	if currentSize < collector.lastPosition {
-		log.Printf("[Beacon] File %s was truncated, resetting position", source.FilePath)
+		logger.Infof("File %s was truncated, resetting position", source.FilePath)
 		collector.lastPosition = 0
 	}
 
@@ -523,7 +522,7 @@ func (lm *LogManager) collectFileLogFromPosition(collector *LogCollector) []LogE
 	// Seek to last position
 	_, err = file.Seek(collector.lastPosition, 0)
 	if err != nil {
-		log.Printf("[Beacon] Error seeking in file %s: %v", source.FilePath, err)
+		logger.Infof("Error seeking in file %s: %v", source.FilePath, err)
 		return nil
 	}
 
@@ -538,7 +537,7 @@ func (lm *LogManager) collectFileLogFromPosition(collector *LogCollector) []LogE
 			break
 		}
 		if err != nil {
-			log.Printf("[Beacon] Error reading file %s: %v", source.FilePath, err)
+			logger.Infof("Error reading file %s: %v", source.FilePath, err)
 			break
 		}
 
@@ -627,7 +626,7 @@ func (lm *LogManager) collectFileLogWithTail(source LogSource, collector *LogCol
 
 	output, err := cmd.Output()
 	if err != nil {
-		log.Printf("[Beacon] Error reading file log %s with tail: %v", source.FilePath, err)
+		logger.Infof("Error reading file log %s with tail: %v", source.FilePath, err)
 		return nil
 	}
 
@@ -676,7 +675,7 @@ func (lm *LogManager) collectFileLogWithTail(source LogSource, collector *LogCol
 // runDockerLogCollection handles Docker container log collection
 func (lm *LogManager) runDockerLogCollection(collector *LogCollector) {
 	source := collector.source
-	log.Printf("[Beacon] Starting docker log collection: %s", source.Name)
+	logger.Infof("Starting docker log collection: %s", source.Name)
 
 	// lastTimestamp set from persisted cursor in StartLogCollection, or from initial interval
 
@@ -715,7 +714,7 @@ func (lm *LogManager) collectDockerLogSince(source LogSource, since time.Time) [
 		cmd := exec.Command("docker", "ps", "--format", "{{.Names}}")
 		output, err := cmd.Output()
 		if err != nil {
-			log.Printf("[Beacon] Error getting docker containers: %v", err)
+			logger.Infof("Error getting docker containers: %v", err)
 			return nil
 		}
 		containers = strings.Split(strings.TrimSpace(string(output)), "\n")
@@ -757,7 +756,7 @@ func (lm *LogManager) collectDockerLogSince(source LogSource, since time.Time) [
 		cmd := exec.Command("docker", args...)
 		output, err := cmd.Output()
 		if err != nil {
-			log.Printf("[Beacon] Error getting docker logs for %s: %v", container, err)
+			logger.Infof("Error getting docker logs for %s: %v", container, err)
 			continue
 		}
 
@@ -791,7 +790,7 @@ func (lm *LogManager) collectDockerLogSince(source LogSource, since time.Time) [
 // runDeployLogCollection handles deploy log collection
 func (lm *LogManager) runDeployLogCollection(collector *LogCollector) {
 	source := collector.source
-	log.Printf("[Beacon] Starting deploy log collection: %s", source.Name)
+	logger.Infof("Starting deploy log collection: %s", source.Name)
 
 	// Deploy logs are captured during deployment
 	// This function monitors the deploy log file if it exists
@@ -829,7 +828,7 @@ func (lm *LogManager) collectDeployLog(source LogSource) []LogEntry {
 	cmd := exec.Command("tail", "-n", fmt.Sprintf("%d", maxLines), source.DeployLogFile)
 	output, err := cmd.Output()
 	if err != nil {
-		log.Printf("[Beacon] Error reading deploy log %s: %v", source.DeployLogFile, err)
+		logger.Infof("Error reading deploy log %s: %v", source.DeployLogFile, err)
 		return nil
 	}
 
@@ -862,7 +861,7 @@ func (lm *LogManager) collectDeployLog(source LogSource) []LogEntry {
 // runCommandLogCollection handles command-based log collection
 func (lm *LogManager) runCommandLogCollection(collector *LogCollector) {
 	source := collector.source
-	log.Printf("[Beacon] Starting command log collection: %s -> %s", source.Name, source.Command)
+	logger.Infof("Starting command log collection: %s -> %s", source.Name, source.Command)
 
 	ticker := time.NewTicker(source.Interval)
 	defer ticker.Stop()
@@ -885,7 +884,7 @@ func (lm *LogManager) collectCommandLog(source LogSource) []LogEntry {
 	cmd := exec.Command("sh", "-c", source.Command)
 	output, err := cmd.Output()
 	if err != nil {
-		log.Printf("[Beacon] Error executing command log %s: %v", source.Command, err)
+		logger.Infof("Error executing command log %s: %v", source.Command, err)
 		return nil
 	}
 
@@ -1029,7 +1028,7 @@ func (lm *LogManager) flushPending(_ bool) {
 		return
 	}
 	lm.reportLogs(pending)
-	log.Printf("[Beacon] Flushed %d log entries", len(pending))
+	logger.Infof("Flushed %d log entries", len(pending))
 }
 
 // addLogEntries adds new log entries to the collection and reports them (batched)
@@ -1088,13 +1087,13 @@ func (lm *LogManager) addLogEntries(entries []LogEntry) {
 			lm.lastFlush = time.Now()
 			lm.pendingMux.Unlock()
 			lm.reportLogs(toSend)
-			log.Printf("[Beacon] Flushed %d log entries (batch full)", len(toSend))
+			logger.Infof("Flushed %d log entries (batch full)", len(toSend))
 		} else {
 			lm.pendingMux.Unlock()
 		}
 	}
 
-	log.Printf("[Beacon] Collected %d log entries (filtered from %d)", len(filteredEntries), len(entries))
+	logger.Infof("Collected %d log entries (filtered from %d)", len(filteredEntries), len(entries))
 }
 
 // reportLogs sends log entries to the external API
@@ -1128,14 +1127,14 @@ func (lm *LogManager) reportLogs(logs []LogEntry) {
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("[Beacon] Failed to marshal logs: %v", err)
+		logger.Infof("Failed to marshal logs: %v", err)
 		return
 	}
 
 	baseURL := strings.TrimSuffix(lm.config.Report.SendTo, "/")
 	req, err := http.NewRequest("POST", baseURL+"/agent/logs", strings.NewReader(string(jsonData)))
 	if err != nil {
-		log.Printf("[Beacon] Failed to create logs report request: %v", err)
+		logger.Infof("Failed to create logs report request: %v", err)
 		return
 	}
 
@@ -1144,14 +1143,14 @@ func (lm *LogManager) reportLogs(logs []LogEntry) {
 
 	resp, err := lm.httpClient.Do(req)
 	if err != nil {
-		log.Printf("[Beacon] Failed to send logs report: %v", err)
+		logger.Infof("Failed to send logs report: %v", err)
 		return
 	}
 	defer util.DeferClose(resp.Body, "HTTP response body")()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		log.Printf("[Beacon] Successfully reported %d log entries", len(logs))
+		logger.Infof("Successfully reported %d log entries", len(logs))
 	} else {
-		log.Printf("[Beacon] Failed to report logs: HTTP %d", resp.StatusCode)
+		logger.Infof("Failed to report logs: HTTP %d", resp.StatusCode)
 	}
 }

--- a/internal/monitor/logging.go
+++ b/internal/monitor/logging.go
@@ -1,0 +1,5 @@
+package monitor
+
+import "beacon/internal/logging"
+
+var logger = logging.New("monitor")

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -331,7 +330,7 @@ func (m *Monitor) persistCheckResults() {
 	stateDir := filepath.Join(getConfigDir(), "state")
 	projectDir := filepath.Join(stateDir, projectName)
 	if err := os.MkdirAll(projectDir, 0755); err != nil {
-		log.Printf("[Beacon] Failed to create state dir: %v", err)
+		logger.Infof("Failed to create state dir: %v", err)
 		return
 	}
 	path := filepath.Join(projectDir, "checks.json")
@@ -351,16 +350,16 @@ func (m *Monitor) persistCheckResults() {
 	st := state.ChecksState{UpdatedAt: time.Now().UTC(), Checks: checks}
 	data, err := json.MarshalIndent(st, "", "  ")
 	if err != nil {
-		log.Printf("[Beacon] Failed to marshal checks state: %v", err)
+		logger.Infof("Failed to marshal checks state: %v", err)
 		return
 	}
 	tmpPath := path + ".tmp"
 	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		log.Printf("[Beacon] Failed to write checks state: %v", err)
+		logger.Infof("Failed to write checks state: %v", err)
 		return
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		log.Printf("[Beacon] Failed to rename checks state: %v", err)
+		logger.Infof("Failed to rename checks state: %v", err)
 		_ = os.Remove(tmpPath)
 	}
 }
@@ -462,20 +461,20 @@ func setAgentAuthHeaders(req *http.Request, token string) {
 func (m *Monitor) reapplyAgentIdentity() {
 	uc, err := identity.LoadUserConfig()
 	if err != nil {
-		log.Printf("[Beacon] Failed to load user config: %v", err)
+		logger.Infof("Failed to load user config: %v", err)
 	} else {
 		applyUserConfigToMonitorConfig(m.config, uc)
 	}
 	ag, err := identity.LoadAgent()
 	if err != nil {
-		log.Printf("[Beacon] Failed to load agent identity: %v", err)
+		logger.Infof("Failed to load agent identity: %v", err)
 		return
 	}
 	m.agentIdentity = ag
 	applyAgentIdentityToMonitorConfig(m.config, ag)
 	tok, err := resolveMonitorAuthToken(m.config, m.keyManager, ag, uc)
 	if err != nil {
-		log.Printf("[Beacon] Failed to resolve agent credentials: %v", err)
+		logger.Infof("Failed to resolve agent credentials: %v", err)
 		return
 	}
 	m.currentToken = tok
@@ -490,7 +489,7 @@ func (m *Monitor) persistAgentDeviceIDIfNew(body []byte) {
 		if uc.DeviceID != resp.DeviceID {
 			uc.DeviceID = resp.DeviceID
 			if err := uc.Save(); err != nil {
-				log.Printf("[Beacon] Failed to save device_id to config.yaml: %v", err)
+				logger.Infof("Failed to save device_id to config.yaml: %v", err)
 			}
 		}
 	}
@@ -504,7 +503,7 @@ func (m *Monitor) persistAgentDeviceIDIfNew(body []byte) {
 	}
 	ag.DeviceID = resp.DeviceID
 	if err := ag.Save(); err != nil {
-		log.Printf("[Beacon] Failed to save device_id to agent.yml: %v", err)
+		logger.Infof("Failed to save device_id to agent.yml: %v", err)
 		return
 	}
 	m.agentIdentity = ag
@@ -536,11 +535,11 @@ func registerBuiltinPlugins(manager *plugins.Manager) error {
 }
 
 func (m *Monitor) Start() error {
-	log.Printf("[Beacon] Starting monitoring system for device: %s", m.config.Device.Name)
+	logger.Infof("Starting monitoring system for device: %s", m.config.Device.Name)
 
 	// Load plugin configurations
 	if err := m.pluginManager.LoadConfigs(m.config.Plugins, m.config.AlertRules); err != nil {
-		log.Printf("[Beacon] Warning: failed to load plugin configurations: %v", err)
+		logger.Infof("Warning: failed to load plugin configurations: %v", err)
 	}
 
 	// Start config hot-reload monitoring
@@ -600,7 +599,7 @@ func (m *Monitor) Start() error {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	log.Println("[Beacon] Shutdown signal received, stopping monitoring...")
+	logger.Infof("Shutdown signal received, stopping monitoring...")
 
 	// Flush last logs synchronously before canceling
 	if len(m.config.LogSources) > 0 && m.config.Report.SendTo != "" && m.currentToken != "" {
@@ -676,9 +675,9 @@ func (m *Monitor) executeCheck(check CheckConfig) {
 	// Log result
 	switch check.Type {
 	case "http":
-		log.Printf("[Beacon] Check (%s) %s: %s (%.2fs)", check.Type, check.Name, result.Status, result.Duration.Seconds())
+		logger.Infof("Check (%s) %s: %s (%.2fs)", check.Type, check.Name, result.Status, result.Duration.Seconds())
 	case "port":
-		log.Printf("[Beacon] Check (%s) %s: %s (%.2fs)", check.Type, check.Name, result.Status, result.Duration.Seconds())
+		logger.Infof("Check (%s) %s: %s (%.2fs)", check.Type, check.Name, result.Status, result.Duration.Seconds())
 	case "command":
 		// Format output with truncation and whitespace normalization
 		output := strings.Join(strings.Fields(result.CommandOutput), " ")
@@ -692,8 +691,8 @@ func (m *Monitor) executeCheck(check CheckConfig) {
 			errorMsg = errorMsg[:maxOutputLength] + "..."
 		}
 
-		log.Printf(
-			"[Beacon] Check (%s) %s: (%.2fs) - Output: %s, Error: %s",
+		logger.Infof(
+			"Check (%s) %s: (%.2fs) - Output: %s, Error: %s",
 			check.Type,
 			check.Name,
 			result.Duration.Seconds(),
@@ -733,17 +732,17 @@ func (m *Monitor) executeCheck(check CheckConfig) {
 		}
 
 		if err := m.pluginManager.SendAlert(pluginResult); err != nil {
-			log.Printf("[Beacon] Failed to send alert via plugins: %v", err)
+			logger.Infof("Failed to send alert via plugins: %v", err)
 		}
 	}
 
 	// Execute alert command for command checks (always run regardless of status)
 	if check.Type == "command" && check.AlertCommand != "" {
-		log.Printf("[Beacon] Executing alert command for command check: %s", result.Name)
+		logger.Infof("Executing alert command for command check: %s", result.Name)
 		m.executeAlertCommand(check.AlertCommand, result)
 	} else if result.Status != "up" && check.AlertCommand != "" {
 		// For non-command checks, only run alert command on failure
-		log.Printf("[Beacon] Executing alert command for failed check: %s", result.Name)
+		logger.Infof("Executing alert command for failed check: %s", result.Name)
 		m.executeAlertCommand(check.AlertCommand, result)
 	}
 }
@@ -914,7 +913,7 @@ func (m *Monitor) executeAlertCommand(command string, result CheckResult) {
 		return
 	}
 
-	log.Printf("[Beacon] Executing alert command for check: %s", result.Name)
+	logger.Infof("Executing alert command for check: %s", result.Name)
 
 	// Execute the alert command in a goroutine to avoid blocking
 	go func() {
@@ -941,9 +940,9 @@ func (m *Monitor) executeAlertCommand(command string, result CheckResult) {
 		err := cmd.Run()
 
 		if err != nil {
-			log.Printf("[Beacon] Alert command failed: %v, stderr: %s", err, stderr.String())
+			logger.Infof("Alert command failed: %v, stderr: %s", err, stderr.String())
 		} else {
-			log.Printf("[Beacon] Alert command executed successfully: %s", stdout.String())
+			logger.Infof("Alert command executed successfully: %s", stdout.String())
 		}
 	}()
 }
@@ -992,13 +991,13 @@ func (m *Monitor) buildAgentMetrics() *AgentMetrics {
 
 	hostname, err := m.metricsCollector.GetHostname()
 	if err != nil {
-		log.Printf("[Beacon] Failed to get hostname: %v", err)
+		logger.Infof("Failed to get hostname: %v", err)
 		return nil
 	}
 
 	ipAddress, err := m.metricsCollector.GetIPAddress()
 	if err != nil {
-		log.Printf("[Beacon] Failed to get IP address: %v", err)
+		logger.Infof("Failed to get IP address: %v", err)
 		ipAddress = "unknown"
 	}
 
@@ -1086,13 +1085,13 @@ func (m *Monitor) sendHeartbeat() {
 
 	hostname, err := getHostname()
 	if err != nil {
-		log.Printf("[Beacon] Failed to get hostname for heartbeat: %v", err)
+		logger.Infof("Failed to get hostname for heartbeat: %v", err)
 		return
 	}
 
 	ipAddress, err := getIPAddress()
 	if err != nil {
-		log.Printf("[Beacon] Failed to get IP address for heartbeat: %v", err)
+		logger.Infof("Failed to get IP address for heartbeat: %v", err)
 		ipAddress = "unknown"
 	}
 
@@ -1122,7 +1121,7 @@ func (m *Monitor) sendHeartbeat() {
 	heartbeatURL := strings.TrimSuffix(m.config.Report.SendTo, "/") + "/agent/heartbeat"
 	body, err := m.doAPIRequest(heartbeatURL, heartbeat)
 	if err != nil {
-		log.Printf("[Beacon] Heartbeat request failed: %v", err)
+		logger.Infof("Heartbeat request failed: %v", err)
 		return
 	}
 	m.persistAgentDeviceIDIfNew(body)
@@ -1135,7 +1134,7 @@ func (m *Monitor) sendHeartbeat() {
 	if body != nil && m.config.Report.DeployOnRequest {
 		var resp heartbeatResponse
 		if jsonErr := json.Unmarshal(body, &resp); jsonErr == nil && resp.DeployRequested {
-			log.Printf("[Beacon] Deploy requested by BeaconWatch, running deploy...")
+			logger.Infof("Deploy requested by BeaconWatch, running deploy...")
 			result := m.runDeployRequested()
 			m.postDeployResult(result)
 		}
@@ -1170,7 +1169,7 @@ func (m *Monitor) runDeployRequested() deployResultPayload {
 	envPath := filepath.Join(getConfigDir(), "config", "projects", projectName, "env")
 	if _, err := os.Stat(envPath); err == nil {
 		if loadErr := util.LoadEnvFile(envPath); loadErr != nil {
-			log.Printf("[Beacon] Failed to load project env: %v", loadErr)
+			logger.Infof("Failed to load project env: %v", loadErr)
 			return deployResultPayload{Success: false, Error: loadErr.Error()}
 		}
 	}
@@ -1193,10 +1192,10 @@ func (m *Monitor) runDeployRequested() deployResultPayload {
 		err = deploy.Deploy(cfg, lastTag, status)
 	}
 	if err != nil {
-		log.Printf("[Beacon] Deploy failed: %v", err)
+		logger.Infof("Deploy failed: %v", err)
 		return deployResultPayload{Success: false, Error: err.Error()}
 	}
-	log.Printf("[Beacon] Deploy completed successfully")
+	logger.Infof("Deploy completed successfully")
 	return deployResultPayload{Success: true}
 }
 
@@ -1215,13 +1214,13 @@ func (m *Monitor) postDeployResult(result deployResultPayload) {
 func (m *Monitor) sendToAPI(url string, payload interface{}) {
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("[Beacon] Failed to marshal payload: %v", err)
+		logger.Infof("Failed to marshal payload: %v", err)
 		return
 	}
 
 	req, err := http.NewRequest("POST", url, strings.NewReader(string(jsonData)))
 	if err != nil {
-		log.Printf("[Beacon] Failed to create API request: %v", err)
+		logger.Infof("Failed to create API request: %v", err)
 		return
 	}
 
@@ -1230,15 +1229,15 @@ func (m *Monitor) sendToAPI(url string, payload interface{}) {
 
 	resp, err := m.httpClient.Do(m.ctx, req)
 	if err != nil {
-		log.Printf("[Beacon] Failed to send to API: %v", err)
+		logger.Infof("Failed to send to API: %v", err)
 		return
 	}
 	defer util.DeferClose(resp.Body, "HTTP response body")()
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		log.Printf("[Beacon] Successfully sent data to %s", url)
+		logger.Infof("Successfully sent data to %s", url)
 	} else {
-		log.Printf("[Beacon] API request failed: HTTP %d", resp.StatusCode)
+		logger.Infof("API request failed: HTTP %d", resp.StatusCode)
 	}
 }
 
@@ -1246,10 +1245,10 @@ func (m *Monitor) startPrometheusServer() {
 	http.HandleFunc("/metrics", m.prometheusHandler)
 
 	addr := fmt.Sprintf(":%d", m.config.Report.PrometheusPort)
-	log.Printf("[Beacon] Prometheus metrics server listening on %s", addr)
+	logger.Infof("Prometheus metrics server listening on %s", addr)
 
 	if err := http.ListenAndServe(addr, nil); err != nil {
-		log.Printf("[Beacon] Prometheus server error: %v", err)
+		logger.Infof("Prometheus server error: %v", err)
 	}
 }
 
@@ -1323,17 +1322,17 @@ func (m *Monitor) writePrometheusFile() {
 	}
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		log.Printf("[Beacon] Failed to create Prometheus file dir: %v", err)
+		logger.Infof("Failed to create Prometheus file dir: %v", err)
 		return
 	}
 	tmpPath := path + ".tmp"
 	content := m.getPrometheusMetricsText()
 	if err := os.WriteFile(tmpPath, []byte(content), 0644); err != nil {
-		log.Printf("[Beacon] Failed to write Prometheus file: %v", err)
+		logger.Infof("Failed to write Prometheus file: %v", err)
 		return
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		log.Printf("[Beacon] Failed to rename Prometheus file: %v", err)
+		logger.Infof("Failed to rename Prometheus file: %v", err)
 		_ = os.Remove(tmpPath)
 	}
 }
@@ -1378,7 +1377,7 @@ func Run(cmd *cobra.Command, args []string) {
 
 // Stop stops the monitor and cleans up resources
 func (m *Monitor) Stop() {
-	log.Printf("[Beacon] Stopping monitoring system")
+	logger.Infof("Stopping monitoring system")
 
 	if m.configWatcher != nil {
 		util.Close(m.configWatcher, "config watcher")
@@ -1394,7 +1393,7 @@ func (m *Monitor) Stop() {
 
 	if m.pluginManager != nil {
 		if err := m.pluginManager.Close(); err != nil {
-			log.Printf("[Beacon] Error closing plugin manager: %v", err)
+			logger.Infof("Error closing plugin manager: %v", err)
 		}
 	}
 
@@ -1406,13 +1405,13 @@ func (m *Monitor) startConfigHotReload() {
 	// Watch the config file
 	err := m.configWatcher.Add(m.configPath)
 	if err != nil {
-		log.Printf("[Beacon] Failed to watch config file: %v", err)
+		logger.Infof("Failed to watch config file: %v", err)
 		return
 	}
 
 	keysDir := filepath.Join(getConfigDir(), "keys")
 	if err := m.configWatcher.Add(keysDir); err != nil {
-		log.Printf("[Beacon] Failed to watch keys directory: %v", err)
+		logger.Infof("Failed to watch keys directory: %v", err)
 	}
 
 	if m.agentYAMLPath != "" {
@@ -1420,7 +1419,7 @@ func (m *Monitor) startConfigHotReload() {
 		cp := filepath.Clean(m.configPath)
 		if ap != cp {
 			if err := m.configWatcher.Add(m.agentYAMLPath); err != nil {
-				log.Printf("[Beacon] Failed to watch agent identity file: %v", err)
+				logger.Infof("Failed to watch agent identity file: %v", err)
 			}
 		}
 	}
@@ -1428,7 +1427,7 @@ func (m *Monitor) startConfigHotReload() {
 		up := filepath.Clean(m.userConfigPath)
 		if up != filepath.Clean(m.configPath) && up != filepath.Clean(m.agentYAMLPath) {
 			if err := m.configWatcher.Add(m.userConfigPath); err != nil {
-				log.Printf("[Beacon] Failed to watch user config.yaml: %v", err)
+				logger.Infof("Failed to watch user config.yaml: %v", err)
 			}
 		}
 	}
@@ -1445,14 +1444,14 @@ func (m *Monitor) startConfigHotReload() {
 				if !ok {
 					return
 				}
-				log.Printf("[Beacon] Config watcher error: %v", err)
+				logger.Infof("Config watcher error: %v", err)
 			case <-m.ctx.Done():
 				return
 			}
 		}
 	}()
 
-	log.Printf("[Beacon] Started config hot-reload monitoring")
+	logger.Infof("Started config hot-reload monitoring")
 }
 
 // handleConfigChange handles configuration file changes
@@ -1463,21 +1462,21 @@ func (m *Monitor) handleConfigChange(event fsnotify.Event) {
 	switch {
 	case event.Op&fsnotify.Write == fsnotify.Write:
 		if filepath.Clean(event.Name) == filepath.Clean(m.configPath) {
-			log.Printf("[Beacon] Config file changed, reloading...")
+			logger.Infof("Config file changed, reloading...")
 			m.reloadConfig()
 		} else if m.agentYAMLPath != "" && filepath.Clean(event.Name) == filepath.Clean(m.agentYAMLPath) {
-			log.Printf("[Beacon] Agent identity file changed, reloading credentials...")
+			logger.Infof("Agent identity file changed, reloading credentials...")
 			m.reloadToken()
 		} else if m.userConfigPath != "" && filepath.Clean(event.Name) == filepath.Clean(m.userConfigPath) {
-			log.Printf("[Beacon] User config.yaml changed, reloading credentials...")
+			logger.Infof("User config.yaml changed, reloading credentials...")
 			m.reloadToken()
 		} else if strings.Contains(event.Name, "keys/") && strings.HasSuffix(event.Name, ".json") {
-			log.Printf("[Beacon] Key file changed, reloading token...")
+			logger.Infof("Key file changed, reloading token...")
 			m.reloadToken()
 		}
 	case event.Op&fsnotify.Create == fsnotify.Create:
 		if strings.Contains(event.Name, "keys/") && strings.HasSuffix(event.Name, ".json") {
-			log.Printf("[Beacon] New key file created, checking for token updates...")
+			logger.Infof("New key file created, checking for token updates...")
 			m.reloadToken()
 		}
 	}
@@ -1487,7 +1486,7 @@ func (m *Monitor) handleConfigChange(event fsnotify.Event) {
 func (m *Monitor) reloadConfig() {
 	newConfig, err := LoadConfig(m.configPath)
 	if err != nil {
-		log.Printf("[Beacon] Failed to reload config: %v", err)
+		logger.Infof("Failed to reload config: %v", err)
 		return
 	}
 
@@ -1495,10 +1494,10 @@ func (m *Monitor) reloadConfig() {
 	m.reapplyAgentIdentity()
 
 	if err := m.pluginManager.LoadConfigs(m.config.Plugins, m.config.AlertRules); err != nil {
-		log.Printf("[Beacon] Failed to reload plugin configurations: %v", err)
+		logger.Infof("Failed to reload plugin configurations: %v", err)
 	}
 
-	log.Printf("[Beacon] Configuration reloaded successfully")
+	logger.Infof("Configuration reloaded successfully")
 }
 
 // reloadToken reloads credentials from the keyring and agent.yml
@@ -1506,6 +1505,6 @@ func (m *Monitor) reloadToken() {
 	prev := m.currentToken
 	m.reapplyAgentIdentity()
 	if m.currentToken != prev {
-		log.Printf("[Beacon] Agent credentials reloaded")
+		logger.Infof("Agent credentials reloaded")
 	}
 }

--- a/internal/plugins/manager.go
+++ b/internal/plugins/manager.go
@@ -2,12 +2,14 @@ package plugins
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
 	"beacon/internal/errors"
+	"beacon/internal/logging"
 )
+
+var logger = logging.New("plugins")
 
 // Manager handles plugin registration, initialization, and alert routing
 type Manager struct {
@@ -41,7 +43,7 @@ func (m *Manager) RegisterPlugin(plugin Plugin) error {
 	}
 
 	m.plugins[name] = plugin
-	log.Printf("[Beacon] Registered plugin: %s", name)
+	logger.Infof("Registered plugin: %s", name)
 	return nil
 }
 
@@ -84,9 +86,9 @@ func (m *Manager) LoadConfigs(configs []PluginConfig, rules []AlertRule) error {
 					beaconErr := errors.NewPluginError(config.Name, err)
 					return beaconErr
 				}
-				log.Printf("[Beacon] Initialized plugin: %s", config.Name)
+				logger.Infof("Initialized plugin: %s", config.Name)
 			} else {
-				log.Printf("[Beacon] Warning: plugin %s not registered", config.Name)
+				logger.Infof("Warning: plugin %s not registered", config.Name)
 			}
 		}
 	}
@@ -120,7 +122,7 @@ func (m *Manager) SendAlert(checkResult *CheckResult) error {
 	// Process each applicable rule
 	for _, rule := range applicableRules {
 		if err := m.processRule(rule, checkResult); err != nil {
-			log.Printf("[Beacon] Error processing alert rule for %s: %v", rule.Check, err)
+			logger.Infof("Error processing alert rule for %s: %v", rule.Check, err)
 		}
 	}
 
@@ -133,7 +135,7 @@ func (m *Manager) processRule(rule AlertRule, checkResult *CheckResult) error {
 	if cooldown, exists := m.cooldowns[rule.Check]; exists {
 		lastAlertTime, exists := m.lastAlert[rule.Check]
 		if exists && time.Since(lastAlertTime) < cooldown {
-			log.Printf("[Beacon] Alert for %s in cooldown period", rule.Check)
+			logger.Infof("Alert for %s in cooldown period", rule.Check)
 			return nil
 		}
 	}
@@ -162,7 +164,7 @@ func (m *Manager) processRule(rule AlertRule, checkResult *CheckResult) error {
 					Err:        err,
 				})
 			} else {
-				log.Printf("[Beacon] Alert sent via plugin: %s", pluginName)
+				logger.Infof("Alert sent via plugin: %s", pluginName)
 			}
 		} else {
 			errors = append(errors, &PluginError{

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,14 +1,16 @@
 package ratelimit
 
 import (
+	"beacon/internal/logging"
 	"beacon/internal/util"
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 	"time"
 )
+
+var logger = logging.New("ratelimit")
 
 // RateLimiter handles rate limiting and backoff for external API calls
 type RateLimiter struct {
@@ -85,7 +87,7 @@ func (rl *RateLimiter) Wait(ctx context.Context) error {
 	if rl.requestCount >= rl.requestsPerMinute {
 		waitTime := time.Minute - now.Sub(rl.windowStart)
 		if waitTime > 0 {
-			log.Printf("[RateLimiter] Rate limit reached, waiting %v", waitTime)
+			logger.Infof("Rate limit reached, waiting %v", waitTime)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -102,7 +104,7 @@ func (rl *RateLimiter) Wait(ctx context.Context) error {
 		timeSinceLastRequest := now.Sub(rl.lastRequest)
 		if timeSinceLastRequest < rl.minInterval {
 			waitTime := rl.minInterval - timeSinceLastRequest
-			log.Printf("[RateLimiter] Minimum interval not met, waiting %v", waitTime)
+			logger.Infof("Minimum interval not met, waiting %v", waitTime)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -113,7 +115,7 @@ func (rl *RateLimiter) Wait(ctx context.Context) error {
 
 	// Apply current backoff if we're in retry mode
 	if rl.retryCount > 0 {
-		log.Printf("[RateLimiter] Applying backoff: %v (retry %d/%d)", rl.currentBackoff, rl.retryCount, rl.maxRetries)
+		logger.Infof("Applying backoff: %v (retry %d/%d)", rl.currentBackoff, rl.retryCount, rl.maxRetries)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -149,9 +151,9 @@ func (rl *RateLimiter) RecordFailure() {
 		if rl.currentBackoff > rl.maxInterval {
 			rl.currentBackoff = rl.maxInterval
 		}
-		log.Printf("[RateLimiter] Failure recorded, new backoff: %v", rl.currentBackoff)
+		logger.Infof("Failure recorded, new backoff: %v", rl.currentBackoff)
 	} else {
-		log.Printf("[RateLimiter] Max retries (%d) exceeded", rl.maxRetries)
+		logger.Infof("Max retries (%d) exceeded", rl.maxRetries)
 	}
 }
 
@@ -224,7 +226,7 @@ func (c *HTTPClient) Do(ctx context.Context, req *http.Request) (*http.Response,
 		// Handle rate limiting responses
 		if resp.StatusCode == 429 {
 			c.rateLimiter.RecordFailure()
-			log.Printf("[RateLimiter] HTTP 429 received, applying backoff")
+			logger.Infof("HTTP 429 received, applying backoff")
 			util.LogError(resp.Body.Close(), "HTTP response body close")
 
 			if !c.rateLimiter.ShouldRetry() {

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -2,14 +2,16 @@ package server
 
 import (
 	"beacon/internal/config"
+	"beacon/internal/logging"
 	"beacon/internal/state"
 
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"time"
 )
+
+var logger = logging.New("server")
 
 type statusResponse struct {
 	LastTag      string `json:"last_tag"`
@@ -26,13 +28,13 @@ func StartHTTPServer(cfg *config.Config, status *state.Status) {
 		w.Header().Set("Content-Type", "application/json")
 		err := json.NewEncoder(w).Encode(resp)
 		if err != nil {
-			log.Printf("[Beacon] Failed to encode status response: %v", err)
+			logger.Infof("Failed to encode status response: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte("Failed to encode status response"))
 			return
 		}
 	})
 
-	log.Printf("[Beacon] Status server listening on :%s\n", cfg.Port)
+	logger.Infof("Status server listening on :%s\n", cfg.Port)
 	http.ListenAndServe(fmt.Sprintf(":%s", cfg.Port), nil)
 }

--- a/internal/tunnel/client.go
+++ b/internal/tunnel/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"beacon/internal/ipc"
+	"beacon/internal/logging"
 
 	"github.com/gorilla/websocket"
 )
@@ -44,6 +44,7 @@ type Client struct {
 	cfg  ClientConfig
 	conn *websocket.Conn
 	mu   sync.Mutex // protects conn writes
+	log  *logging.Logger
 
 	// Active WebSocket passthrough streams (streamID -> local ws conn)
 	streams sync.Map
@@ -56,6 +57,7 @@ type Client struct {
 func NewClient(cfg ClientConfig) *Client {
 	return &Client{
 		cfg:       cfg,
+		log:       logging.New("tunnel " + cfg.TunnelID),
 		startedAt: time.Now(),
 	}
 }
@@ -92,7 +94,7 @@ func (c *Client) Run(ctx context.Context) error {
 
 		attempt++
 		if attempt > maxReconnects {
-			log.Printf("[Beacon tunnel %s] Max reconnects (%d) exceeded, giving up", c.cfg.TunnelID, maxReconnects)
+			c.log.Warnf("Max reconnects (%d) exceeded, giving up", maxReconnects)
 			c.connected = false
 			c.writeHealthOnce()
 			return fmt.Errorf("max reconnects exceeded after error: %v", err)
@@ -102,8 +104,8 @@ func (c *Client) Run(ctx context.Context) error {
 		if backoff > maxBackoff {
 			backoff = maxBackoff
 		}
-		log.Printf("[Beacon tunnel %s] Disconnected (%v), reconnecting in %v (attempt %d/%d)",
-			c.cfg.TunnelID, err, backoff, attempt, maxReconnects)
+		c.log.Infof("Disconnected (%v), reconnecting in %v (attempt %d/%d)",
+			err, backoff, attempt, maxReconnects)
 		c.connected = false
 		c.writeHealthOnce()
 
@@ -135,7 +137,7 @@ func (c *Client) connectAndServe(ctx context.Context) error {
 	c.connected = true
 	c.mu.Unlock()
 
-	log.Printf("[Beacon tunnel %s] Connected to %s", c.cfg.TunnelID, wsURL)
+	c.log.Infof("Connected to %s", wsURL)
 
 	defer c.closeConn()
 
@@ -160,7 +162,7 @@ func (c *Client) connectAndServe(ctx context.Context) error {
 
 		var msg Message
 		if err := json.Unmarshal(raw, &msg); err != nil {
-			log.Printf("[Beacon tunnel %s] Invalid message: %v", c.cfg.TunnelID, err)
+			c.log.Warnf("Invalid message: %v", err)
 			continue
 		}
 
@@ -176,7 +178,7 @@ func (c *Client) connectAndServe(ctx context.Context) error {
 		case MsgPing:
 			c.sendMessage(&Message{Type: MsgPong})
 		default:
-			log.Printf("[Beacon tunnel %s] Unknown message type: %s", c.cfg.TunnelID, msg.Type)
+			c.log.Warnf("Unknown message type: %s", msg.Type)
 		}
 	}
 }
@@ -184,7 +186,7 @@ func (c *Client) connectAndServe(ctx context.Context) error {
 func (c *Client) handleHTTPRequest(msg Message) {
 	resp, err := ProxyHTTPRequest(c.cfg.LocalPort, &msg)
 	if err != nil {
-		log.Printf("[Beacon tunnel %s] Proxy error for %s %s: %v", c.cfg.TunnelID, msg.Method, msg.Path, err)
+		c.log.Errorf("Proxy error for %s %s: %v", msg.Method, msg.Path, err)
 		resp = &Message{
 			Type:      MsgHTTPResponse,
 			RequestID: msg.RequestID,
@@ -198,7 +200,7 @@ func (c *Client) handleHTTPRequest(msg Message) {
 func (c *Client) handleWSOpen(ctx context.Context, msg Message) {
 	localConn, err := ProxyWSOpen(ctx, c.cfg.LocalPort, msg.Path, msg.Headers)
 	if err != nil {
-		log.Printf("[Beacon tunnel %s] WS open failed for %s: %v", c.cfg.TunnelID, msg.Path, err)
+		c.log.Errorf("WS open failed for %s: %v", msg.Path, err)
 		c.sendMessage(&Message{
 			Type:     MsgWSOpenResult,
 			StreamID: msg.StreamID,
@@ -266,7 +268,7 @@ func (c *Client) sendMessage(msg *Message) {
 	}
 	_ = c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	if err := c.conn.WriteJSON(msg); err != nil {
-		log.Printf("[Beacon tunnel %s] Write error: %v", c.cfg.TunnelID, err)
+		c.log.Errorf("Write error: %v", err)
 	}
 }
 

--- a/internal/tunnel/manager.go
+++ b/internal/tunnel/manager.go
@@ -3,13 +3,15 @@ package tunnel
 import (
 	"context"
 	"fmt"
-	"log"
 	"path/filepath"
 	"sync"
 
 	"beacon/internal/identity"
 	"beacon/internal/ipc"
+	"beacon/internal/logging"
 )
+
+var managerLog = logging.New("tunnel")
 
 // MaxActiveTunnels is the maximum number of tunnels that can be active simultaneously per user.
 // Matches the server-side limit. Additional configured tunnels stay dormant.
@@ -91,9 +93,9 @@ func (tm *TunnelManager) start(t identity.TunnelConfig, cloudURL, apiKey, device
 	tm.wg.Add(1)
 	go func() {
 		defer tm.wg.Done()
-		log.Printf("[Beacon master] Starting tunnel %s -> localhost:%d", t.ID, t.LocalPort)
+		managerLog.Infof("Starting tunnel %s -> localhost:%d", t.ID, t.LocalPort)
 		if err := client.Run(tm.ctx); err != nil && tm.ctx.Err() == nil {
-			log.Printf("[Beacon master] Tunnel %s stopped: %v", t.ID, err)
+			managerLog.Warnf("Tunnel %s stopped: %v", t.ID, err)
 		}
 	}()
 }
@@ -133,10 +135,10 @@ func (tm *TunnelManager) GetTunnelStatuses() []TunnelStatus {
 
 // Shutdown stops all tunnel goroutines and waits for them to finish.
 func (tm *TunnelManager) Shutdown() {
-	log.Printf("[Beacon master] Stopping all tunnels...")
+	managerLog.Infof("Stopping all tunnels...")
 	tm.cancel()
 	tm.wg.Wait()
-	log.Printf("[Beacon master] All tunnels stopped")
+	managerLog.Infof("All tunnels stopped")
 }
 
 func isTunnelEnabled(t identity.TunnelConfig) bool {

--- a/internal/util/closer.go
+++ b/internal/util/closer.go
@@ -2,24 +2,26 @@ package util
 
 import (
 	"io"
-	"log"
+
+	"beacon/internal/logging"
 )
 
 // Closer provides safe resource closing with error logging
 type Closer struct {
-	prefix string
+	log *logging.Logger
 }
 
-// NewCloser creates a new Closer with an optional log prefix
+// NewCloser creates a new Closer. An optional prefix becomes the logger component name.
 func NewCloser(prefix string) *Closer {
-	if prefix == "" {
-		prefix = "[Beacon]"
+	name := prefix
+	if name == "" {
+		name = "util"
 	}
-	return &Closer{prefix: prefix}
+	return &Closer{log: logging.New(name)}
 }
 
 // DefaultCloser is a package-level closer with the default prefix
-var DefaultCloser = NewCloser("[Beacon]")
+var DefaultCloser = NewCloser("")
 
 // Close safely closes any io.Closer and logs errors
 func (c *Closer) Close(closer io.Closer, resource string) {
@@ -27,7 +29,7 @@ func (c *Closer) Close(closer io.Closer, resource string) {
 		return
 	}
 	if err := closer.Close(); err != nil {
-		log.Printf("%s Failed to close %s: %v", c.prefix, resource, err)
+		c.log.Errorf("Failed to close %s: %v", resource, err)
 	}
 }
 

--- a/internal/util/closer_test.go
+++ b/internal/util/closer_test.go
@@ -3,14 +3,14 @@ package util
 import (
 	"bytes"
 	"errors"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"beacon/internal/logging"
 )
 
 // mockCloser implements io.Closer for testing
@@ -62,8 +62,8 @@ func TestCloser_Close(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Capture log output
 			var buf bytes.Buffer
-			log.SetOutput(&buf)
-			defer log.SetOutput(os.Stderr)
+			logging.SetOutput(&buf)
+			defer logging.SetOutput(nil)
 
 			closer := NewCloser("[Test]")
 			mock := &mockCloser{shouldError: tt.shouldError}
@@ -87,8 +87,8 @@ func TestCloser_Close(t *testing.T) {
 
 func TestCloser_CloseFile(t *testing.T) {
 	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
+	logging.SetOutput(&buf)
+	defer logging.SetOutput(nil)
 
 	closer := NewCloser("[Test]")
 	mock := &mockCloser{shouldError: true}
@@ -107,8 +107,8 @@ func TestCloser_CloseFile(t *testing.T) {
 
 func TestCloser_CloseConn(t *testing.T) {
 	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
+	logging.SetOutput(&buf)
+	defer logging.SetOutput(nil)
 
 	closer := NewCloser("[Test]")
 	mock := &mockConn{mockCloser{shouldError: true}}
@@ -127,8 +127,8 @@ func TestCloser_CloseConn(t *testing.T) {
 
 func TestCloser_CloseResponse(t *testing.T) {
 	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
+	logging.SetOutput(&buf)
+	defer logging.SetOutput(nil)
 
 	closer := NewCloser("[Test]")
 
@@ -154,8 +154,8 @@ func TestCloser_CloseResponse(t *testing.T) {
 
 func TestDeferFunctions(t *testing.T) {
 	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
+	logging.SetOutput(&buf)
+	defer logging.SetOutput(nil)
 
 	mock := &mockCloser{shouldError: true}
 
@@ -175,8 +175,8 @@ func TestDeferFunctions(t *testing.T) {
 
 func TestPackageLevelFunctions(t *testing.T) {
 	var buf bytes.Buffer
-	log.SetOutput(&buf)
-	defer log.SetOutput(os.Stderr)
+	logging.SetOutput(&buf)
+	defer logging.SetOutput(nil)
 
 	mock := &mockCloser{shouldError: false}
 
@@ -217,8 +217,8 @@ func TestLogError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			log.SetOutput(&buf)
-			defer log.SetOutput(os.Stderr)
+			logging.SetOutput(&buf)
+			defer logging.SetOutput(nil)
 
 			LogError(tt.err, tt.operation)
 

--- a/internal/util/log.go
+++ b/internal/util/log.go
@@ -1,10 +1,12 @@
 package util
 
-import "log"
+import "beacon/internal/logging"
+
+var logger = logging.New("util")
 
 // LogError logs an error if it's not nil, with a descriptive message
 func LogError(err error, operation string) {
 	if err != nil {
-		log.Printf("[Beacon] Failed to %s: %v", operation, err)
+		logger.Errorf("Failed to %s: %v", operation, err)
 	}
 }


### PR DESCRIPTION
# Structured logger with per-component prefixes

## Summary

Replaces stdlib `log` across Beacon with a thin in-house `internal/logging` package so every component logs under its own prefix. Previously the child agent always logged as `[Beacon child]` regardless of which project it ran, which made multi-project deployments hard to follow. Now:

- master → `[Beacon master]`
- child → `[Beacon <projectID>]` (e.g. `[Beacon home-assistant]`)
- tunnel → `[Beacon tunnel <tunnelID>]`
- deploy / monitor / ratelimit / plugins / alerting / cli / util → `[Beacon <component>]`

Also adds a `log_level` field to `UserConfig` (valid values: `debug`, `info`, `warn`, `error`; default `info`) with `BEACON_LOG_LEVEL` env var taking precedence. Master applies its configured level at startup and exports it to the environment so spawned children inherit the same level.

## What changed

### New package: `internal/logging`

Thin Printf-style logger with a baked-in prefix. Output format matches the old stdlib log (`YYYY/MM/DD HH:MM:SS [Beacon name] message`) so existing log consumers are unaffected.

```go
logging.New("master")               // -> [Beacon master]
logging.New(cfg.ProjectID)          // -> [Beacon home-assistant]
logging.New("tunnel " + id)         // -> [Beacon tunnel abc123]

logger.Infof("started on :%s", port)
logger.Warnf(...)
logger.Errorf(...)
logger.Debugf(...)
logger.Fatalf(...)                  // logs then os.Exit(1)

logging.SetLevel("debug")           // no-op if BEACON_LOG_LEVEL set
logging.SetOutput(w)                // for tests
```

Level filtering is global and atomic. Non-info levels get a `LEVEL:` tag in the output; info stays clean to match the old format.

### Migration

Mechanical sweep of 25+ files in `internal/` and `cmd/` — `log.Printf("[Beacon X] msg", ...)` → `logger.Infof("msg", ...)`, stripping the now-redundant prefix from every format string. `log.Fatal*` → `logger.Fatalf`.

Two components get instance-scoped loggers stored on their struct:

- **Child** (`internal/child/child.go`): `c.log = logging.New(cfg.ProjectID)` in `New()`. A `logger()` getter lazy-initializes a fallback so tests that construct `Child` directly don't need to wire the logger.
- **Tunnel** (`internal/tunnel/client.go`): `c.log = logging.New("tunnel " + cfg.TunnelID)` in the constructor. Removes the old manually-formatted `"[Beacon tunnel %s]"` strings.

### UserConfig + log level propagation

- `internal/identity/userconfig.go`: adds `LogLevel string \`yaml:"log_level,omitempty"\``.
- `internal/master/run.go`: after config load, calls `logging.SetLevel(uc.LogLevel)` and exports `BEACON_LOG_LEVEL` to the environment if not already set, so child processes inherit it.
- `BEACON_LOG_LEVEL` env var, if set at process start, takes precedence over any programmatic `SetLevel` call.

### Utility cleanup

`internal/util/closer.go` and `internal/util/log.go` now use `internal/logging` instead of stdlib log. `closer_test.go` switched to `logging.SetOutput(&buf)` for output capture.

## Files

- **New:** `internal/logging/logging.go`, `internal/logging/logging_test.go`
- **Modified:** `cmd/beacon/{main,cloud,tunnel,config_cmd,logging}.go`, `internal/master/*.go`, `internal/child/child.go`, `internal/tunnel/{client,manager,proxy}.go`, `internal/deploy/*.go`, `internal/monitor/*.go`, `internal/ratelimit/ratelimit.go`, `internal/plugins/manager.go`, `internal/alerting/{alert,cli}.go`, `internal/server/http.go`, `internal/k8sobserver/informers.go`, `internal/mcp/server.go`, `internal/util/{closer,log,closer_test}.go`, `internal/identity/userconfig.go`

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...` — all packages pass, including new `internal/logging` tests covering prefix formatting, level filtering, env override, and the fact that info has no level tag while other levels do.
- `grep -rn '"log"' --include='*.go' internal/ cmd/` returns only `internal/logging/logging.go` (plus the unrelated `tests/k8s/mock-log-server/main.go` standalone utility)..
