### PR TITLE
Feature: Local Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ docker_images:
 
 Beacon talks to the registry API, detects the newest tag, pulls it, and runs your command. Supports Docker Hub, GHCR, and any Registry v2-compatible registry. Multiple images in one project are tracked independently — only the changed image redeploys.
 
+### Project secrets
+
+Beacon can store encrypted deploy-time secrets per project and environment:
+
+```bash
+beacon secrets set API_TOKEN --project myapp --env prod
+beacon secrets list --project myapp --env prod
+beacon secrets list --reveal --project myapp --env prod
+beacon secrets export --reveal --project myapp --env prod
+```
+
+Secrets live under `~/.beacon/secrets/<project>/<env>.enc` and are encrypted with a local AES-256-GCM machine key at `~/.beacon/secrets/key`. The key is created automatically with `0600` permissions.
+
+During deploys, Beacon starts from the process environment, loads the existing `BEACON_SECURE_ENV_PATH` `.env` file when configured, then overlays Beacon secrets. That means Beacon secrets override matching `.env` values. Set `BEACON_PROJECT_ENV=prod` in the project env file to select an environment; if it is not set, Beacon uses `default`.
+
+Values are not printed unless you pass `--reveal`. Use `list` for key names only, `list --reveal` to inspect all values, and `export --reveal --format env|json` for scripts.
+
+Security note: the machine key is stored locally next to the encrypted secret files. This protects against accidental commits, backup leakage, and casual inspection; it is not meant to protect against someone who can already read your Beacon home directory.
+
 ### Health checks
 
 ```yaml
@@ -264,6 +283,7 @@ Everything here works without an internet connection and without signing up for 
 | **Test your alert setup without waiting for an outage** | `beacon alerts test --project myapp --severity critical` |
 | **Forward logs** from a file, a Docker container, or `journalctl` | Add a `log_sources:` block to your `monitor.yml`. Filter with include/exclude patterns so you only ship what you care about. |
 | **Keep your tokens out of config files** | `beacon keys add` — encrypted local token store for Git, Docker, webhooks. |
+| **Keep deploy secrets out of `.env` files** | `beacon secrets set API_TOKEN --project myapp --env prod`. Beacon injects them after `.env` values during deploy. |
 | **Access Home Assistant, Grafana, or any local service remotely** (with a BeaconInfra account — authenticated, no port-forwarding needed) | `beacon tunnel add homeassistant --port 8123` |
 | **Run several tunnels at once** | `beacon tunnel list` / `beacon tunnel enable` / `beacon tunnel disable` |
 | **Route traffic through your home network from your laptop** | `beacon vpn enable` on the exit node, `beacon vpn use <device>` on the client. Peer-to-peer WireGuard. |
@@ -296,7 +316,7 @@ Even with BeaconInfra enabled, some things stay on your device and never touch t
 
 - Your **source code** and **deploy scripts** — the cloud only sends a "deploy now" signal; your device runs the script.
 - Your **tokens** (Git, Docker, webhooks) — encrypted locally by `beacon keys`.
-- Your **application secrets** (database passwords, API keys loaded via `secure_env_path`) — Beacon hands them to your app at deploy time and nothing else.
+- Your **application secrets** (database passwords, API keys loaded via `BEACON_SECURE_ENV_PATH` or `beacon secrets`) — Beacon hands them to your app at deploy time and nothing else.
 - **Raw log files** — only the lines you explicitly configured as `log_sources` are forwarded. Everything else stays on disk.
 - The **local dashboard** at port 9100 — it keeps working offline, BeaconInfra account or not.
 
@@ -343,6 +363,7 @@ Projects are isolated: one crash doesn't affect others. The master auto-restarts
 | `beacon cloud login` / `logout` | Enable/disable cloud |
 | `beacon bootstrap <name>` | Set up a project (interactive or `-f config.yml`) |
 | `beacon deploy` | Git/Docker tag polling loop |
+| `beacon secrets set\|get\|list\|export\|remove` | Local encrypted deploy secrets |
 | `beacon tunnel add\|list\|enable\|disable` | Reverse tunnels for remote access |
 | `beacon vpn enable\|use\|disable\|status` | WireGuard VPN |
 | `beacon projects list\|add\|remove\|status` | Project management |

--- a/beacon.env.example
+++ b/beacon.env.example
@@ -14,6 +14,9 @@ BEACON_GIT_TOKEN=
 # Local deployment path
 BEACON_LOCAL_PATH=/home/pi/project
 
+# Project environment for Beacon-managed secrets (optional)
+BEACON_PROJECT_ENV=default
+
 # Deploy command to run after update (optional)
 # Example: "docker compose up --build -d" or "./install.sh"
 BEACON_DEPLOY_CMD=docker compose up --build -d
@@ -25,5 +28,4 @@ BEACON_POLL_INTERVAL=60s
 BEACON_PORT=8080
 
 BEACON_SECURE_ENV_PATH=/etc/yourproject/.env
-
 

--- a/cmd/beacon/main.go
+++ b/cmd/beacon/main.go
@@ -14,6 +14,7 @@ import (
 	"beacon/internal/deploy"
 	"beacon/internal/keys"
 	"beacon/internal/projects"
+	"beacon/internal/secrets"
 	"beacon/internal/server"
 	"beacon/internal/state"
 	"beacon/internal/version"
@@ -307,6 +308,7 @@ func main() {
 	rootCmd.AddCommand(restartCmd)
 	rootCmd.AddCommand(wizardCmd)
 	rootCmd.AddCommand(keys.KeysCmd)
+	rootCmd.AddCommand(secrets.Command())
 	rootCmd.AddCommand(alerting.CreateSimpleAlertingCommand())
 	rootCmd.AddCommand(projects.CreateProjectCommand())
 	rootCmd.AddCommand(createMCPCommand())

--- a/examples/beacon.bootstrap.docker.yml
+++ b/examples/beacon.bootstrap.docker.yml
@@ -3,6 +3,7 @@
 
 # Project configuration
 project_name: "my-docker-app"
+# project_env: "default"  # Optional environment for Beacon-managed secrets
 deployment_type: "docker"  # Use Docker registry instead of Git
 
 # Docker images configuration (array of images to monitor individually)
@@ -66,4 +67,3 @@ use_system_service: false  # Set to true for system-wide service
 #   * Environment-specific: docker-compose.yml + docker-compose.prod.yml
 #   * Service separation: docker-compose.web.yml + docker-compose.worker.yml
 # - Use docker compose -f file1.yml -f file2.yml ... to use multiple files
-

--- a/examples/beacon.bootstrap.example.yml
+++ b/examples/beacon.bootstrap.example.yml
@@ -3,6 +3,7 @@
 
 # Project configuration
 project_name: "my-awesome-app"
+# project_env: "default"  # Optional environment for Beacon-managed secrets
 deployment_type: "git"  # Options: "git" or "docker"
 
 # Git repository configuration (used when deployment_type is "git")

--- a/internal/backup/manager_test.go
+++ b/internal/backup/manager_test.go
@@ -93,7 +93,7 @@ exit 0
 		t.Fatalf("RunNow blocked for %v", elapsed)
 	}
 
-	eventually(t, time.Second, func() bool {
+	eventually(t, 5*time.Second, func() bool {
 		return !m.Status().Running && !m.Status().LastRunAt.IsZero()
 	})
 }

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -34,6 +34,7 @@ type DockerImageBootstrapConfig struct {
 // BootstrapConfig holds configuration for bootstrapping a new Beacon project
 type BootstrapConfig struct {
 	ProjectName    string `yaml:"project_name"`
+	ProjectEnv     string `yaml:"project_env,omitempty"`
 	DeploymentType string `yaml:"deployment_type"` // "git" or "docker"
 
 	// Git repository configuration
@@ -603,6 +604,9 @@ BEACON_SECURE_ENV_PATH={{.SecureEnvPath}}
 
 # Project metadata
 BEACON_PROJECT_NAME={{.ProjectName}}
+{{if .ProjectEnv}}
+BEACON_PROJECT_ENV={{.ProjectEnv}}
+{{end}}
 BEACON_USER={{.User}}
 BEACON_WORKING_DIR={{.WorkingDir}}
 `

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,6 +155,7 @@ func getOptionalBoolEnv(key string) *bool {
 		v := enabled
 		return &v
 	}
+	_, _ = fmt.Fprintf(os.Stderr, "[Beacon] Warning: Ignoring invalid boolean value for %s=%q (expected true/false)\n", key, value)
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,11 +41,14 @@ type Config struct {
 	DockerImages []DockerImageConfig
 
 	// Common configuration
-	PollInterval  time.Duration
-	Port          string
-	DeployCommand string // Legacy: kept for backward compatibility
-	SecureEnvPath string // Path to secure environment file for deploy command
-	ProjectDir    string
+	PollInterval   time.Duration
+	Port           string
+	DeployCommand  string // Legacy: kept for backward compatibility
+	SecureEnvPath  string // Path to secure environment file for deploy command
+	ProjectDir     string
+	ProjectName    string
+	ProjectEnv     string
+	SecretsEnabled *bool
 }
 
 func Load() *Config {
@@ -65,12 +68,21 @@ func Load() *Config {
 		deploymentType = "git" // Default to git if invalid
 	}
 
+	projectName := os.Getenv("BEACON_PROJECT_NAME")
+	projectEnv := os.Getenv("BEACON_PROJECT_ENV")
+	if projectEnv == "" {
+		projectEnv = "default"
+	}
+
 	cfg := &Config{
 		DeploymentType: deploymentType,
 		PollInterval:   getDurationEnv("BEACON_POLL_INTERVAL", 60*time.Second),
 		Port:           getEnvOrPrompt("BEACON_PORT", "Enter the port to run on", "8080"),
 		DeployCommand:  getEnvOrPrompt("BEACON_DEPLOY_CMD", "Enter the deploy command to run after update (optional)", ""),
 		SecureEnvPath:  getEnvOrPrompt("BEACON_SECURE_ENV_PATH", "Enter secure environment file path (optional)", "$HOME/beacon/project/.env"),
+		ProjectName:    projectName,
+		ProjectEnv:     projectEnv,
+		SecretsEnabled: getOptionalBoolEnv("BEACON_SECRETS_ENABLED"),
 	}
 
 	switch deploymentType {
@@ -85,9 +97,8 @@ func Load() *Config {
 		cfg.LocalPath = os.ExpandEnv(getEnvOrPrompt("BEACON_LOCAL_PATH", "Enter the local path for the project", "$HOME/beacon/project"))
 		ensureDir(cfg.LocalPath)
 
-		projectName := os.Getenv("BEACON_PROJECT_NAME")
-		if projectName == "" {
-			projectName = filepath.Base(cfg.LocalPath)
+		if cfg.ProjectName == "" {
+			cfg.ProjectName = filepath.Base(cfg.LocalPath)
 		}
 
 		// Load Docker images from docker-images.yml if it exists
@@ -95,7 +106,7 @@ func Load() *Config {
 		if err != nil {
 			base = filepath.Join(os.Getenv("HOME"), ".beacon")
 		}
-		dockerImagesPath := filepath.Join(base, "config", "projects", projectName, "docker-images.yml")
+		dockerImagesPath := filepath.Join(base, "config", "projects", cfg.ProjectName, "docker-images.yml")
 		if images, err := loadDockerImagesConfig(dockerImagesPath); err == nil {
 			cfg.DockerImages = images
 		} else if !os.IsNotExist(err) {
@@ -103,6 +114,9 @@ func Load() *Config {
 		}
 	}
 	cfg.ProjectDir = filepath.Base(cfg.LocalPath)
+	if cfg.ProjectName == "" {
+		cfg.ProjectName = cfg.ProjectDir
+	}
 
 	return cfg
 }
@@ -128,6 +142,20 @@ func getDurationEnv(key string, defaultValue time.Duration) time.Duration {
 		}
 	}
 	return defaultValue
+}
+
+func getOptionalBoolEnv(key string) *bool {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return nil
+	}
+	enabled := value == "1" || strings.EqualFold(value, "true") || strings.EqualFold(value, "yes") || strings.EqualFold(value, "on")
+	disabled := value == "0" || strings.EqualFold(value, "false") || strings.EqualFold(value, "no") || strings.EqualFold(value, "off")
+	if enabled || disabled {
+		v := enabled
+		return &v
+	}
+	return nil
 }
 
 func getEnvOrPrompt(key, prompt, defaultValue string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,90 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoad(t *testing.T) {
+	t.Run("project metadata and secrets settings", func(t *testing.T) {
+		localPath := filepath.Join(t.TempDir(), "app")
+		t.Setenv("BEACON_DEPLOYMENT_TYPE", "git")
+		t.Setenv("BEACON_LOCAL_PATH", localPath)
+		t.Setenv("BEACON_REPO_URL", "https://example.com/repo.git")
+		t.Setenv("BEACON_PORT", "9090")
+		t.Setenv("BEACON_POLL_INTERVAL", "2m")
+		t.Setenv("BEACON_DEPLOY_CMD", "./deploy.sh")
+		t.Setenv("BEACON_SECURE_ENV_PATH", "")
+		t.Setenv("BEACON_PROJECT_NAME", "myapp")
+		t.Setenv("BEACON_PROJECT_ENV", "prod")
+		t.Setenv("BEACON_SECRETS_ENABLED", "true")
+
+		cfg := Load()
+		if cfg.ProjectName != "myapp" {
+			t.Fatalf("ProjectName = %q, want myapp", cfg.ProjectName)
+		}
+		if cfg.ProjectEnv != "prod" {
+			t.Fatalf("ProjectEnv = %q, want prod", cfg.ProjectEnv)
+		}
+		if cfg.SecretsEnabled == nil || !*cfg.SecretsEnabled {
+			t.Fatalf("SecretsEnabled = %v, want true", cfg.SecretsEnabled)
+		}
+		if cfg.PollInterval != 2*time.Minute {
+			t.Fatalf("PollInterval = %v, want 2m", cfg.PollInterval)
+		}
+	})
+
+	t.Run("defaults project env and project name", func(t *testing.T) {
+		localPath := filepath.Join(t.TempDir(), "fallback-app")
+		t.Setenv("BEACON_DEPLOYMENT_TYPE", "git")
+		t.Setenv("BEACON_LOCAL_PATH", localPath)
+		t.Setenv("BEACON_REPO_URL", "https://example.com/repo.git")
+		t.Setenv("BEACON_SECURE_ENV_PATH", "")
+		t.Setenv("BEACON_PROJECT_ENV", "")
+		t.Setenv("BEACON_PROJECT_NAME", "")
+		t.Setenv("BEACON_SECRETS_ENABLED", "")
+
+		cfg := Load()
+		if cfg.ProjectEnv != "default" {
+			t.Fatalf("ProjectEnv = %q, want default", cfg.ProjectEnv)
+		}
+		if cfg.ProjectName != "fallback-app" {
+			t.Fatalf("ProjectName = %q, want fallback-app", cfg.ProjectName)
+		}
+	})
+}
+
+func TestGetOptionalBoolEnv(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  *bool
+	}{
+		{name: "missing", value: "", want: nil},
+		{name: "true", value: "true", want: boolPtr(true)},
+		{name: "one", value: "1", want: boolPtr(true)},
+		{name: "false", value: "false", want: boolPtr(false)},
+		{name: "zero", value: "0", want: boolPtr(false)},
+		{name: "invalid", value: "maybe", want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TEST_BOOL", tt.value)
+			got := getOptionalBoolEnv("TEST_BOOL")
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("getOptionalBoolEnv() = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil || *got != *tt.want {
+				t.Fatalf("getOptionalBoolEnv() = %v, want %v", got, *tt.want)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/internal/deploy/credential_state.go
+++ b/internal/deploy/credential_state.go
@@ -2,8 +2,10 @@ package deploy
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 )
 
@@ -18,13 +20,34 @@ type CredentialErrorRecord struct {
 const credentialErrorsFile = "credential_errors.json"
 const credentialErrorMaxAge = 24 * time.Hour
 
-func credentialErrorPath(stateDir, projectID string) string {
-	return filepath.Join(stateDir, projectID, credentialErrorsFile)
+var credentialProjectIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+func credentialErrorPath(stateDir, projectID string) (string, error) {
+	if err := validateCredentialProjectID(projectID); err != nil {
+		return "", err
+	}
+	return filepath.Join(stateDir, projectID, credentialErrorsFile), nil
+}
+
+func validateCredentialProjectID(projectID string) error {
+	if projectID == "" {
+		return fmt.Errorf("project id cannot be empty")
+	}
+	if projectID == "." || projectID == ".." || filepath.IsAbs(projectID) || filepath.Base(projectID) != projectID {
+		return fmt.Errorf("invalid project id %q", projectID)
+	}
+	if !credentialProjectIDPattern.MatchString(projectID) {
+		return fmt.Errorf("invalid project id %q", projectID)
+	}
+	return nil
 }
 
 // RecordCredentialError persists a credential error for the given project.
 func RecordCredentialError(stateDir, projectID string, authErr *AuthError) error {
-	p := credentialErrorPath(stateDir, projectID)
+	p, err := credentialErrorPath(stateDir, projectID)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
 		return err
 	}
@@ -65,7 +88,10 @@ func RecordCredentialError(stateDir, projectID string, authErr *AuthError) error
 
 // ReadCredentialErrors returns unexpired credential errors for a project.
 func ReadCredentialErrors(stateDir, projectID string) []CredentialErrorRecord {
-	p := credentialErrorPath(stateDir, projectID)
+	p, err := credentialErrorPath(stateDir, projectID)
+	if err != nil {
+		return nil
+	}
 	all := readRawErrors(p)
 	cutoff := time.Now().Add(-credentialErrorMaxAge)
 	fresh := make([]CredentialErrorRecord, 0, len(all))
@@ -79,7 +105,12 @@ func ReadCredentialErrors(stateDir, projectID string) []CredentialErrorRecord {
 
 // ClearCredentialErrors removes the credential error file for a project.
 func ClearCredentialErrors(stateDir, projectID string) {
-	if err := os.Remove(credentialErrorPath(stateDir, projectID)); err != nil && !os.IsNotExist(err) {
+	p, err := credentialErrorPath(stateDir, projectID)
+	if err != nil {
+		logger.Infof("Refusing to clear credential errors for invalid project id %q: %v", projectID, err)
+		return
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 		logger.Infof("Failed to clear credential errors for %s: %v", projectID, err)
 	}
 }

--- a/internal/deploy/credential_state.go
+++ b/internal/deploy/credential_state.go
@@ -79,7 +79,9 @@ func ReadCredentialErrors(stateDir, projectID string) []CredentialErrorRecord {
 
 // ClearCredentialErrors removes the credential error file for a project.
 func ClearCredentialErrors(stateDir, projectID string) {
-	os.Remove(credentialErrorPath(stateDir, projectID))
+	if err := os.Remove(credentialErrorPath(stateDir, projectID)); err != nil && !os.IsNotExist(err) {
+		logger.Infof("Failed to clear credential errors for %s: %v", projectID, err)
+	}
 }
 
 func readRawErrors(path string) []CredentialErrorRecord {

--- a/internal/deploy/credential_state_test.go
+++ b/internal/deploy/credential_state_test.go
@@ -1,0 +1,148 @@
+package deploy
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCredentialErrorPath(t *testing.T) {
+	t.Run("rejects unsafe project ids", func(t *testing.T) {
+		stateDir := t.TempDir()
+		unsafeProjectIDs := []string{
+			"../other",
+			"..",
+			".",
+			"/tmp/other",
+			`nested/project`,
+			`nested\project`,
+			"project id",
+		}
+
+		for _, projectID := range unsafeProjectIDs {
+			if _, err := credentialErrorPath(stateDir, projectID); err == nil {
+				t.Fatalf("credentialErrorPath(%q) error = nil, want error", projectID)
+			}
+		}
+	})
+
+	t.Run("allows safe project id", func(t *testing.T) {
+		stateDir := t.TempDir()
+		path, err := credentialErrorPath(stateDir, "project_1-api.prod")
+		if err != nil {
+			t.Fatalf("credentialErrorPath() error = %v", err)
+		}
+		want := filepath.Join(stateDir, "project_1-api.prod", credentialErrorsFile)
+		if path != want {
+			t.Fatalf("credentialErrorPath() = %q, want %q", path, want)
+		}
+	})
+}
+
+func TestCredentialErrorsLifecycle(t *testing.T) {
+	t.Run("record read replace and clear", func(t *testing.T) {
+		stateDir := t.TempDir()
+		authErr := &AuthError{Type: "git", Code: 401, Message: "bad token"}
+		if err := RecordCredentialError(stateDir, "myapp", authErr); err != nil {
+			t.Fatalf("RecordCredentialError() error = %v", err)
+		}
+
+		records := ReadCredentialErrors(stateDir, "myapp")
+		if len(records) != 1 {
+			t.Fatalf("records len = %d, want 1", len(records))
+		}
+		if records[0].Type != "git" || records[0].ErrorCode != 401 || records[0].Message != "bad token" {
+			t.Fatalf("record = %#v, want persisted auth error", records[0])
+		}
+
+		authErr.Message = "new token error"
+		if err := RecordCredentialError(stateDir, "myapp", authErr); err != nil {
+			t.Fatalf("RecordCredentialError() replace error = %v", err)
+		}
+		records = ReadCredentialErrors(stateDir, "myapp")
+		if len(records) != 1 || records[0].Message != "new token error" {
+			t.Fatalf("records after replace = %#v", records)
+		}
+
+		ClearCredentialErrors(stateDir, "myapp")
+		if records := ReadCredentialErrors(stateDir, "myapp"); len(records) != 0 {
+			t.Fatalf("records after clear = %#v, want empty", records)
+		}
+	})
+
+	t.Run("filters expired and invalid records", func(t *testing.T) {
+		stateDir := t.TempDir()
+		path, err := credentialErrorPath(stateDir, "myapp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		old := time.Now().Add(-credentialErrorMaxAge - time.Hour)
+		fresh := time.Now()
+		data := `[
+  {"type":"git","message":"old","detected_at":"` + old.Format(time.RFC3339Nano) + `"},
+  {"type":"docker","message":"fresh","detected_at":"` + fresh.Format(time.RFC3339Nano) + `"}
+]`
+		if err := os.WriteFile(path, []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+		records := ReadCredentialErrors(stateDir, "myapp")
+		if len(records) != 1 || records[0].Type != "docker" {
+			t.Fatalf("records = %#v, want only fresh docker record", records)
+		}
+
+		if err := os.WriteFile(path, []byte("not-json"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if records := ReadCredentialErrors(stateDir, "myapp"); len(records) != 0 {
+			t.Fatalf("invalid json records = %#v, want empty", records)
+		}
+	})
+
+	t.Run("record rejects unsafe project id", func(t *testing.T) {
+		err := RecordCredentialError(t.TempDir(), "../bad", &AuthError{Type: "git", Message: "bad"})
+		if err == nil {
+			t.Fatal("RecordCredentialError() error = nil, want unsafe project id error")
+		}
+	})
+}
+
+func TestClearCredentialErrors(t *testing.T) {
+	t.Run("rejects traversal", func(t *testing.T) {
+		stateDir := t.TempDir()
+		outsideDir := t.TempDir()
+		outsideFile := filepath.Join(outsideDir, credentialErrorsFile)
+		if err := os.WriteFile(outsideFile, []byte("keep"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		ClearCredentialErrors(stateDir, filepath.Join("..", filepath.Base(outsideDir)))
+
+		if _, err := os.Stat(outsideFile); err != nil {
+			t.Fatalf("outside file was affected: %v", err)
+		}
+	})
+
+	t.Run("ignores missing file", func(t *testing.T) {
+		ClearCredentialErrors(t.TempDir(), "myapp")
+	})
+
+	t.Run("handles remove error", func(t *testing.T) {
+		stateDir := t.TempDir()
+		path, err := credentialErrorPath(stateDir, "myapp")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+		ClearCredentialErrors(stateDir, "myapp")
+		if _, err := os.Stat(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat path after failed clear: %v", err)
+		}
+	})
+}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -137,25 +137,15 @@ func Deploy(cfg *config.Config, tag string, status *state.Status) error {
 	if cfg.DeployCommand != "" {
 		logger.Infof("Executing deploy command: %s\n", cfg.DeployCommand)
 
-		// Build the command with secure environment file sourcing
-		var command string
-		if cfg.SecureEnvPath != "" {
-			// Check if secure env file exists
-			if _, err := os.Stat(cfg.SecureEnvPath); err == nil {
-				logger.Infof("Sourcing secure environment file: %s\n", cfg.SecureEnvPath)
-				command = fmt.Sprintf("set -a && . %s && set +a && %s", cfg.SecureEnvPath, cfg.DeployCommand)
-			} else {
-				logger.Infof("Warning: Secure environment file not found: %s\n", cfg.SecureEnvPath)
-				logger.Infof("Running deploy command without secure environment\n")
-				command = cfg.DeployCommand
-			}
-		} else {
-			command = cfg.DeployCommand
+		env, err := CommandEnv(cfg)
+		if err != nil {
+			return err
 		}
 
 		// Execute the command - set working directory to avoid CWD issues
-		cmd := exec.Command("sh", "-c", command)
+		cmd := exec.Command("sh", "-c", cfg.DeployCommand)
 		cmd.Dir = cfg.LocalPath // Set working directory to project directory
+		cmd.Env = env
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 
@@ -227,17 +217,13 @@ func DeployBranch(cfg *config.Config, branch string, status *state.Status) error
 
 	if cfg.DeployCommand != "" {
 		logger.Infof("Executing deploy command: %s\n", cfg.DeployCommand)
-		command := cfg.DeployCommand
-		if cfg.SecureEnvPath != "" {
-			if _, err := os.Stat(cfg.SecureEnvPath); err == nil {
-				logger.Infof("Sourcing secure environment file: %s\n", cfg.SecureEnvPath)
-				command = fmt.Sprintf("set -a && . %s && set +a && %s", cfg.SecureEnvPath, cfg.DeployCommand)
-			} else {
-				logger.Infof("Warning: Secure environment file not found: %s\n", cfg.SecureEnvPath)
-			}
+		env, err := CommandEnv(cfg)
+		if err != nil {
+			return err
 		}
-		cmd := exec.Command("sh", "-c", command)
+		cmd := exec.Command("sh", "-c", cfg.DeployCommand)
 		cmd.Dir = cfg.LocalPath
+		cmd.Env = env
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {

--- a/internal/deploy/docker.go
+++ b/internal/deploy/docker.go
@@ -337,24 +337,11 @@ func DeployDockerImage(imgCfg *config.DockerImageConfig, cfg *config.Config, tag
 	if deployCommand != "" {
 		logger.Infof("Executing deploy command: %s\n", deployCommand)
 
-		// Build the command with secure environment file sourcing
-		var command string
-		if cfg.SecureEnvPath != "" {
-			if _, err := os.Stat(cfg.SecureEnvPath); err == nil {
-				logger.Infof("Sourcing secure environment file: %s\n", cfg.SecureEnvPath)
-				command = fmt.Sprintf("set -a && . %s && set +a && %s", cfg.SecureEnvPath, deployCommand)
-			} else {
-				logger.Infof("Warning: Secure environment file not found: %s\n", cfg.SecureEnvPath)
-				command = deployCommand
-			}
-		} else {
-			command = deployCommand
-		}
-
 		// Set environment variables for use in deploy command
-		env := os.Environ()
-		env = append(env, fmt.Sprintf("BEACON_DOCKER_IMAGE=%s", fullImageName))
-		env = append(env, fmt.Sprintf("BEACON_DOCKER_TAG=%s", tag))
+		extraEnv := []string{
+			fmt.Sprintf("BEACON_DOCKER_IMAGE=%s", fullImageName),
+			fmt.Sprintf("BEACON_DOCKER_TAG=%s", tag),
+		}
 
 		// Use DockerComposeFiles array (legacy DockerComposeFile is normalized during config load)
 		composeFiles := imgCfg.DockerComposeFiles
@@ -379,7 +366,7 @@ func DeployDockerImage(imgCfg *config.DockerImageConfig, cfg *config.Config, tag
 
 			// Set environment variables for compose files
 			// BEACON_DOCKER_COMPOSE_FILES: Space-separated list of all files (for docker compose -f usage)
-			env = append(env, fmt.Sprintf("BEACON_DOCKER_COMPOSE_FILES=%s", strings.Join(resolvedPaths, " ")))
+			extraEnv = append(extraEnv, fmt.Sprintf("BEACON_DOCKER_COMPOSE_FILES=%s", strings.Join(resolvedPaths, " ")))
 		}
 
 		// Set working directory to LocalPath
@@ -393,8 +380,13 @@ func DeployDockerImage(imgCfg *config.DockerImageConfig, cfg *config.Config, tag
 			workingDir = filepath.Dir(composePath)
 		}
 
+		env, err := CommandEnv(cfg, extraEnv...)
+		if err != nil {
+			return err
+		}
+
 		// Execute the command
-		cmd := exec.Command("sh", "-c", command)
+		cmd := exec.Command("sh", "-c", deployCommand)
 		cmd.Dir = workingDir
 		cmd.Env = env
 		cmd.Stdout = os.Stdout

--- a/internal/deploy/env.go
+++ b/internal/deploy/env.go
@@ -8,6 +8,7 @@ import (
 
 	"beacon/internal/config"
 	"beacon/internal/secrets"
+	"beacon/internal/util"
 )
 
 func CommandEnv(cfg *config.Config, extra ...string) ([]string, error) {
@@ -86,7 +87,7 @@ func readEnvFile(path string, base map[string]string) (map[string]string, error)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer util.DeferClose(file, "env file")()
 
 	values := make(map[string]string, len(base))
 	for key, value := range base {

--- a/internal/deploy/env.go
+++ b/internal/deploy/env.go
@@ -1,0 +1,138 @@
+package deploy
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"beacon/internal/config"
+	"beacon/internal/secrets"
+)
+
+func CommandEnv(cfg *config.Config, extra ...string) ([]string, error) {
+	envMap := envSliceToMap(os.Environ())
+
+	if cfg.SecureEnvPath != "" {
+		path := os.ExpandEnv(cfg.SecureEnvPath)
+		values, err := readEnvFile(path, envMap)
+		if err != nil {
+			if os.IsNotExist(err) {
+				logger.Infof("Warning: Secure environment file not found: %s\n", path)
+			} else {
+				return nil, fmt.Errorf("load secure env file %s: %w", path, err)
+			}
+		} else {
+			logger.Infof("Loading secure environment file: %s\n", path)
+			for key, value := range values {
+				envMap[key] = value
+			}
+		}
+	}
+
+	if err := mergeBeaconSecrets(cfg, envMap); err != nil {
+		return nil, err
+	}
+
+	for _, item := range extra {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	env := make([]string, 0, len(envMap))
+	for key, value := range envMap {
+		env = append(env, key+"="+value)
+	}
+	return env, nil
+}
+
+func mergeBeaconSecrets(cfg *config.Config, envMap map[string]string) error {
+	if cfg.ProjectName == "" {
+		return nil
+	}
+	projectEnv := cfg.ProjectEnv
+	if projectEnv == "" {
+		projectEnv = "default"
+	}
+	store, err := secrets.NewStore()
+	if err != nil {
+		return err
+	}
+	exists, err := store.Exists(cfg.ProjectName, projectEnv)
+	if err != nil {
+		return err
+	}
+	if cfg.SecretsEnabled != nil {
+		if !*cfg.SecretsEnabled {
+			return nil
+		}
+	} else if !exists {
+		return nil
+	}
+	values, err := store.Load(cfg.ProjectName, projectEnv)
+	if err != nil {
+		return fmt.Errorf("load Beacon secrets for %s/%s: %w", cfg.ProjectName, projectEnv, err)
+	}
+	for key, value := range values {
+		envMap[key] = value
+	}
+	return nil
+}
+
+func readEnvFile(path string, base map[string]string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	values := make(map[string]string, len(base))
+	for key, value := range base {
+		values[key] = value
+	}
+	out := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key == "" {
+			continue
+		}
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+		value = os.Expand(value, func(key string) string {
+			return values[key]
+		})
+		values[key] = value
+		out[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read env file: %w", err)
+	}
+	return out, nil
+}
+
+func envSliceToMap(env []string) map[string]string {
+	values := map[string]string{}
+	for _, item := range env {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) == 2 {
+			values[parts[0]] = parts[1]
+		}
+	}
+	return values
+}

--- a/internal/deploy/env.go
+++ b/internal/deploy/env.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -12,11 +11,11 @@ import (
 )
 
 func CommandEnv(cfg *config.Config, extra ...string) ([]string, error) {
-	envMap := envSliceToMap(os.Environ())
+	envMap := util.EnvSliceToMap(os.Environ())
 
 	if cfg.SecureEnvPath != "" {
 		path := os.ExpandEnv(cfg.SecureEnvPath)
-		values, err := readEnvFile(path, envMap)
+		values, err := util.ReadEnvFileMap(path, envMap)
 		if err != nil {
 			if os.IsNotExist(err) {
 				logger.Infof("Warning: Secure environment file not found: %s\n", path)
@@ -61,16 +60,18 @@ func mergeBeaconSecrets(cfg *config.Config, envMap map[string]string) error {
 	if err != nil {
 		return err
 	}
-	exists, err := store.Exists(cfg.ProjectName, projectEnv)
-	if err != nil {
-		return err
-	}
 	if cfg.SecretsEnabled != nil {
 		if !*cfg.SecretsEnabled {
 			return nil
 		}
-	} else if !exists {
-		return nil
+	} else {
+		exists, err := store.Exists(cfg.ProjectName, projectEnv)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return nil
+		}
 	}
 	values, err := store.Load(cfg.ProjectName, projectEnv)
 	if err != nil {
@@ -80,60 +81,4 @@ func mergeBeaconSecrets(cfg *config.Config, envMap map[string]string) error {
 		envMap[key] = value
 	}
 	return nil
-}
-
-func readEnvFile(path string, base map[string]string) (map[string]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer util.DeferClose(file, "env file")()
-
-	values := make(map[string]string, len(base))
-	for key, value := range base {
-		values[key] = value
-	}
-	out := map[string]string{}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		if key == "" {
-			continue
-		}
-		if len(value) >= 2 {
-			if (value[0] == '"' && value[len(value)-1] == '"') ||
-				(value[0] == '\'' && value[len(value)-1] == '\'') {
-				value = value[1 : len(value)-1]
-			}
-		}
-		value = os.Expand(value, func(key string) string {
-			return values[key]
-		})
-		values[key] = value
-		out[key] = value
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read env file: %w", err)
-	}
-	return out, nil
-}
-
-func envSliceToMap(env []string) map[string]string {
-	values := map[string]string{}
-	for _, item := range env {
-		parts := strings.SplitN(item, "=", 2)
-		if len(parts) == 2 {
-			values[parts[0]] = parts[1]
-		}
-	}
-	return values
 }

--- a/internal/deploy/env_test.go
+++ b/internal/deploy/env_test.go
@@ -9,100 +9,118 @@ import (
 	"beacon/internal/secrets"
 )
 
-func TestCommandEnvMissingSecretsDoesNotFail(t *testing.T) {
-	t.Setenv("BEACON_HOME", t.TempDir())
-	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod"}
-	if _, err := CommandEnv(cfg); err != nil {
-		t.Fatalf("CommandEnv() error = %v", err)
-	}
-}
+func TestCommandEnv(t *testing.T) {
+	t.Run("missing secrets does not fail", func(t *testing.T) {
+		t.Setenv("BEACON_HOME", t.TempDir())
+		cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod"}
+		if _, err := CommandEnv(cfg); err != nil {
+			t.Fatalf("CommandEnv() error = %v", err)
+		}
+	})
 
-func TestCommandEnvLoadsSecureEnvFile(t *testing.T) {
-	t.Setenv("BEACON_HOME", t.TempDir())
-	envFile := filepath.Join(t.TempDir(), "secure.env")
-	if err := os.WriteFile(envFile, []byte("FROM_ENV=1\nQUOTED=\"hello\"\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecureEnvPath: envFile}
-	env, err := CommandEnv(cfg)
-	if err != nil {
-		t.Fatalf("CommandEnv() error = %v", err)
-	}
-	if got := envValue(env, "FROM_ENV"); got != "1" {
-		t.Fatalf("FROM_ENV = %q, want 1", got)
-	}
-	if got := envValue(env, "QUOTED"); got != "hello" {
-		t.Fatalf("QUOTED = %q, want hello", got)
-	}
-}
+	t.Run("loads secure env file", func(t *testing.T) {
+		t.Setenv("BEACON_HOME", t.TempDir())
+		envFile := filepath.Join(t.TempDir(), "secure.env")
+		if err := os.WriteFile(envFile, []byte("FROM_ENV=1\nQUOTED=\"hello\"\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecureEnvPath: envFile}
+		env, err := CommandEnv(cfg)
+		if err != nil {
+			t.Fatalf("CommandEnv() error = %v", err)
+		}
+		if got := envValue(env, "FROM_ENV"); got != "1" {
+			t.Fatalf("FROM_ENV = %q, want 1", got)
+		}
+		if got := envValue(env, "QUOTED"); got != "hello" {
+			t.Fatalf("QUOTED = %q, want hello", got)
+		}
+	})
 
-func TestCommandEnvSecretsOverrideSecureEnv(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("BEACON_HOME", home)
-	envFile := filepath.Join(t.TempDir(), "secure.env")
-	if err := os.WriteFile(envFile, []byte("TOKEN=from-env\n"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	store, err := secrets.NewStore()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := store.Set("myapp", "prod", "TOKEN", "from-secret"); err != nil {
-		t.Fatal(err)
-	}
-	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecureEnvPath: envFile}
-	env, err := CommandEnv(cfg)
-	if err != nil {
-		t.Fatalf("CommandEnv() error = %v", err)
-	}
-	if got := envValue(env, "TOKEN"); got != "from-secret" {
-		t.Fatalf("TOKEN = %q, want from-secret", got)
-	}
-}
+	t.Run("secrets override secure env", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("BEACON_HOME", home)
+		envFile := filepath.Join(t.TempDir(), "secure.env")
+		if err := os.WriteFile(envFile, []byte("TOKEN=from-env\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		store, err := secrets.NewStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Set("myapp", "prod", "TOKEN", "from-secret"); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecureEnvPath: envFile}
+		env, err := CommandEnv(cfg)
+		if err != nil {
+			t.Fatalf("CommandEnv() error = %v", err)
+		}
+		if got := envValue(env, "TOKEN"); got != "from-secret" {
+			t.Fatalf("TOKEN = %q, want from-secret", got)
+		}
+	})
 
-func TestCommandEnvCorruptedExistingSecretsFails(t *testing.T) {
-	t.Setenv("BEACON_HOME", t.TempDir())
-	store, err := secrets.NewStore()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := store.Set("myapp", "prod", "TOKEN", "secret"); err != nil {
-		t.Fatal(err)
-	}
-	path, err := store.Path("myapp", "prod")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("broken"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod"}
-	if _, err := CommandEnv(cfg); err == nil {
-		t.Fatal("CommandEnv() error = nil, want corrupted secrets error")
-	}
-}
+	t.Run("corrupted existing secrets fails", func(t *testing.T) {
+		t.Setenv("BEACON_HOME", t.TempDir())
+		store, err := secrets.NewStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Set("myapp", "prod", "TOKEN", "secret"); err != nil {
+			t.Fatal(err)
+		}
+		path, err := store.Path("myapp", "prod")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("broken"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod"}
+		if _, err := CommandEnv(cfg); err == nil {
+			t.Fatal("CommandEnv() error = nil, want corrupted secrets error")
+		}
+	})
 
-func TestCommandEnvSecretsDisabledSkipsExistingFile(t *testing.T) {
-	t.Setenv("BEACON_HOME", t.TempDir())
-	store, err := secrets.NewStore()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := store.Set("myapp", "prod", "TOKEN", "secret"); err != nil {
-		t.Fatal(err)
-	}
-	path, err := store.Path("myapp", "prod")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("broken"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	disabled := false
-	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecretsEnabled: &disabled}
-	if _, err := CommandEnv(cfg); err != nil {
-		t.Fatalf("CommandEnv() error = %v, want nil when secrets disabled", err)
-	}
+	t.Run("secrets disabled skips existing file", func(t *testing.T) {
+		t.Setenv("BEACON_HOME", t.TempDir())
+		store, err := secrets.NewStore()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Set("myapp", "prod", "TOKEN", "secret"); err != nil {
+			t.Fatal(err)
+		}
+		path, err := store.Path("myapp", "prod")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("broken"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		disabled := false
+		cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecretsEnabled: &disabled}
+		if _, err := CommandEnv(cfg); err != nil {
+			t.Fatalf("CommandEnv() error = %v, want nil when secrets disabled", err)
+		}
+	})
+
+	t.Run("extra env overrides merged values", func(t *testing.T) {
+		t.Setenv("BEACON_HOME", t.TempDir())
+		envFile := filepath.Join(t.TempDir(), "secure.env")
+		if err := os.WriteFile(envFile, []byte("TOKEN=from-env\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecureEnvPath: envFile}
+		env, err := CommandEnv(cfg, "TOKEN=from-extra")
+		if err != nil {
+			t.Fatalf("CommandEnv() error = %v", err)
+		}
+		if got := envValue(env, "TOKEN"); got != "from-extra" {
+			t.Fatalf("TOKEN = %q, want from-extra", got)
+		}
+	})
 }
 
 func envValue(env []string, key string) string {

--- a/internal/deploy/env_test.go
+++ b/internal/deploy/env_test.go
@@ -1,0 +1,116 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"beacon/internal/config"
+	"beacon/internal/secrets"
+)
+
+func TestCommandEnvMissingSecretsDoesNotFail(t *testing.T) {
+	t.Setenv("BEACON_HOME", t.TempDir())
+	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod"}
+	if _, err := CommandEnv(cfg); err != nil {
+		t.Fatalf("CommandEnv() error = %v", err)
+	}
+}
+
+func TestCommandEnvLoadsSecureEnvFile(t *testing.T) {
+	t.Setenv("BEACON_HOME", t.TempDir())
+	envFile := filepath.Join(t.TempDir(), "secure.env")
+	if err := os.WriteFile(envFile, []byte("FROM_ENV=1\nQUOTED=\"hello\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecureEnvPath: envFile}
+	env, err := CommandEnv(cfg)
+	if err != nil {
+		t.Fatalf("CommandEnv() error = %v", err)
+	}
+	if got := envValue(env, "FROM_ENV"); got != "1" {
+		t.Fatalf("FROM_ENV = %q, want 1", got)
+	}
+	if got := envValue(env, "QUOTED"); got != "hello" {
+		t.Fatalf("QUOTED = %q, want hello", got)
+	}
+}
+
+func TestCommandEnvSecretsOverrideSecureEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("BEACON_HOME", home)
+	envFile := filepath.Join(t.TempDir(), "secure.env")
+	if err := os.WriteFile(envFile, []byte("TOKEN=from-env\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := secrets.NewStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("myapp", "prod", "TOKEN", "from-secret"); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecureEnvPath: envFile}
+	env, err := CommandEnv(cfg)
+	if err != nil {
+		t.Fatalf("CommandEnv() error = %v", err)
+	}
+	if got := envValue(env, "TOKEN"); got != "from-secret" {
+		t.Fatalf("TOKEN = %q, want from-secret", got)
+	}
+}
+
+func TestCommandEnvCorruptedExistingSecretsFails(t *testing.T) {
+	t.Setenv("BEACON_HOME", t.TempDir())
+	store, err := secrets.NewStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("myapp", "prod", "TOKEN", "secret"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := store.Path("myapp", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("broken"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod"}
+	if _, err := CommandEnv(cfg); err == nil {
+		t.Fatal("CommandEnv() error = nil, want corrupted secrets error")
+	}
+}
+
+func TestCommandEnvSecretsDisabledSkipsExistingFile(t *testing.T) {
+	t.Setenv("BEACON_HOME", t.TempDir())
+	store, err := secrets.NewStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("myapp", "prod", "TOKEN", "secret"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := store.Path("myapp", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("broken"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	disabled := false
+	cfg := &config.Config{ProjectName: "myapp", ProjectEnv: "prod", SecretsEnabled: &disabled}
+	if _, err := CommandEnv(cfg); err != nil {
+		t.Fatalf("CommandEnv() error = %v, want nil when secrets disabled", err)
+	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, item := range env {
+		if len(item) >= len(prefix) && item[:len(prefix)] == prefix {
+			return item[len(prefix):]
+		}
+	}
+	return ""
+}

--- a/internal/identity/userconfig.go
+++ b/internal/identity/userconfig.go
@@ -49,6 +49,7 @@ type UserSystemMetricsConfig struct {
 type ProjectConfig struct {
 	ID         string `yaml:"id"`          // Unique project identifier
 	ConfigPath string `yaml:"config_path"` // Path to the project's monitor.yml
+	Env        string `yaml:"env,omitempty"`
 	// Enabled is tri-state:
 	// nil => omitted in YAML (default: true)
 	// true/false => explicitly set.

--- a/internal/secrets/cli.go
+++ b/internal/secrets/cli.go
@@ -15,23 +15,31 @@ import (
 )
 
 func Command() *cobra.Command {
-	var project string
-	var env string
+	opts := &commandOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "secrets",
 		Short: "Manage encrypted project secrets",
 	}
 
-	cmd.PersistentFlags().StringVar(&project, "project", "", "Project name")
-	cmd.PersistentFlags().StringVar(&env, "env", "", "Deployment environment (default: project config, env file, or default)")
+	cmd.PersistentFlags().StringVar(&opts.project, "project", "", "Project name")
+	cmd.PersistentFlags().StringVar(&opts.env, "env", "", "Deployment environment (default: project config, env file, or default)")
+	cmd.AddCommand(newSetCommand(opts), newGetCommand(opts), newListCommand(opts), newExportCommand(opts), newRemoveCommand(opts))
+	return cmd
+}
 
-	setCmd := &cobra.Command{
+type commandOptions struct {
+	project string
+	env     string
+}
+
+func newSetCommand(opts *commandOptions) *cobra.Command {
+	return &cobra.Command{
 		Use:   "set KEY [VALUE]",
 		Short: "Set a secret",
 		Args:  cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resolvedEnv, err := resolveCLIEnv(project, env)
+			resolvedEnv, err := resolveCLIEnv(opts.project, opts.env)
 			if err != nil {
 				return err
 			}
@@ -39,9 +47,13 @@ func Command() *cobra.Command {
 			if len(args) == 2 {
 				value = args[1]
 			} else {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Secret value: ")
+				if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Secret value: "); err != nil {
+					return err
+				}
 				data, err := term.ReadPassword(int(os.Stdin.Fd()))
-				fmt.Fprintln(cmd.ErrOrStderr())
+				if _, printErr := fmt.Fprintln(cmd.ErrOrStderr()); printErr != nil && err == nil {
+					return printErr
+				}
 				if err != nil {
 					return fmt.Errorf("read secret value: %w", err)
 				}
@@ -51,15 +63,17 @@ func Command() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := store.Set(project, resolvedEnv, args[0], value); err != nil {
+			if err := store.Set(opts.project, resolvedEnv, args[0], value); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Secret %s set for %s/%s\n", args[0], project, resolvedEnv)
-			return nil
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Secret %s set for %s/%s\n", args[0], opts.project, resolvedEnv)
+			return err
 		},
 	}
+}
 
-	getCmd := &cobra.Command{
+func newGetCommand(opts *commandOptions) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "get KEY",
 		Short: "Get a secret value",
 		Args:  cobra.ExactArgs(1),
@@ -68,7 +82,7 @@ func Command() *cobra.Command {
 			if !reveal {
 				return fmt.Errorf("refusing to print secret without --reveal")
 			}
-			resolvedEnv, err := resolveCLIEnv(project, env)
+			resolvedEnv, err := resolveCLIEnv(opts.project, opts.env)
 			if err != nil {
 				return err
 			}
@@ -76,23 +90,26 @@ func Command() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			value, err := store.Get(project, resolvedEnv, args[0])
+			value, err := store.Get(opts.project, resolvedEnv, args[0])
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), value)
-			return nil
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), value)
+			return err
 		},
 	}
-	getCmd.Flags().Bool("reveal", false, "Print the secret value")
+	cmd.Flags().Bool("reveal", false, "Print the secret value")
+	return cmd
+}
 
-	listCmd := &cobra.Command{
+func newListCommand(opts *commandOptions) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List secret keys",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reveal, _ := cmd.Flags().GetBool("reveal")
-			resolvedEnv, err := resolveCLIEnv(project, env)
+			resolvedEnv, err := resolveCLIEnv(opts.project, opts.env)
 			if err != nil {
 				return err
 			}
@@ -101,28 +118,25 @@ func Command() *cobra.Command {
 				return err
 			}
 			if reveal {
-				values, err := store.Load(project, resolvedEnv)
+				values, err := store.Load(opts.project, resolvedEnv)
 				if err != nil {
 					return err
 				}
-				for _, key := range sortedSecretKeys(values) {
-					fmt.Fprintf(cmd.OutOrStdout(), "%s=%s\n", key, shellQuote(values[key]))
-				}
-			} else {
-				keys, err := store.List(project, resolvedEnv)
-				if err != nil {
-					return err
-				}
-				for _, key := range keys {
-					fmt.Fprintln(cmd.OutOrStdout(), key)
-				}
+				return printEnvValues(cmd, values)
 			}
-			return nil
+			keys, err := store.List(opts.project, resolvedEnv)
+			if err != nil {
+				return err
+			}
+			return printLines(cmd, keys)
 		},
 	}
-	listCmd.Flags().Bool("reveal", false, "Print secret values")
+	cmd.Flags().Bool("reveal", false, "Print secret values")
+	return cmd
+}
 
-	exportCmd := &cobra.Command{
+func newExportCommand(opts *commandOptions) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:   "export",
 		Short: "Export secrets",
 		Args:  cobra.NoArgs,
@@ -132,7 +146,7 @@ func Command() *cobra.Command {
 				return fmt.Errorf("refusing to export secrets without --reveal")
 			}
 			format, _ := cmd.Flags().GetString("format")
-			resolvedEnv, err := resolveCLIEnv(project, env)
+			resolvedEnv, err := resolveCLIEnv(opts.project, opts.env)
 			if err != nil {
 				return err
 			}
@@ -140,36 +154,37 @@ func Command() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			values, err := store.Load(project, resolvedEnv)
+			values, err := store.Load(opts.project, resolvedEnv)
 			if err != nil {
 				return err
 			}
 			switch format {
 			case "env":
-				for _, key := range sortedSecretKeys(values) {
-					fmt.Fprintf(cmd.OutOrStdout(), "%s=%s\n", key, shellQuote(values[key]))
-				}
+				return printEnvValues(cmd, values)
 			case "json":
 				encoded, err := json.MarshalIndent(values, "", "  ")
 				if err != nil {
 					return err
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), string(encoded))
+				_, err = fmt.Fprintln(cmd.OutOrStdout(), string(encoded))
+				return err
 			default:
 				return fmt.Errorf("unsupported export format %q (use env or json)", format)
 			}
-			return nil
 		},
 	}
-	exportCmd.Flags().Bool("reveal", false, "Print secret values")
-	exportCmd.Flags().String("format", "env", "Export format: env or json")
+	cmd.Flags().Bool("reveal", false, "Print secret values")
+	cmd.Flags().String("format", "env", "Export format: env or json")
+	return cmd
+}
 
-	removeCmd := &cobra.Command{
+func newRemoveCommand(opts *commandOptions) *cobra.Command {
+	return &cobra.Command{
 		Use:   "remove KEY",
 		Short: "Remove a secret",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resolvedEnv, err := resolveCLIEnv(project, env)
+			resolvedEnv, err := resolveCLIEnv(opts.project, opts.env)
 			if err != nil {
 				return err
 			}
@@ -177,16 +192,13 @@ func Command() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := store.Remove(project, resolvedEnv, args[0]); err != nil {
+			if err := store.Remove(opts.project, resolvedEnv, args[0]); err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "Secret %s removed from %s/%s\n", args[0], project, resolvedEnv)
-			return nil
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Secret %s removed from %s/%s\n", args[0], opts.project, resolvedEnv)
+			return err
 		},
 	}
-
-	cmd.AddCommand(setCmd, getCmd, listCmd, exportCmd, removeCmd)
-	return cmd
 }
 
 func sortedSecretKeys(values map[string]string) []string {
@@ -196,6 +208,24 @@ func sortedSecretKeys(values map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func printEnvValues(cmd *cobra.Command, values map[string]string) error {
+	for _, key := range sortedSecretKeys(values) {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s=%s\n", key, shellQuote(values[key])); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printLines(cmd *cobra.Command, lines []string) error {
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(cmd.OutOrStdout(), line); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func shellQuote(value string) string {

--- a/internal/secrets/cli.go
+++ b/internal/secrets/cli.go
@@ -1,0 +1,271 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"beacon/internal/config"
+	"beacon/internal/identity"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+func Command() *cobra.Command {
+	var project string
+	var env string
+
+	cmd := &cobra.Command{
+		Use:   "secrets",
+		Short: "Manage encrypted project secrets",
+	}
+
+	cmd.PersistentFlags().StringVar(&project, "project", "", "Project name")
+	cmd.PersistentFlags().StringVar(&env, "env", "", "Deployment environment (default: project config, env file, or default)")
+
+	setCmd := &cobra.Command{
+		Use:   "set KEY [VALUE]",
+		Short: "Set a secret",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolvedEnv, err := resolveCLIEnv(project, env)
+			if err != nil {
+				return err
+			}
+			value := ""
+			if len(args) == 2 {
+				value = args[1]
+			} else {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Secret value: ")
+				data, err := term.ReadPassword(int(os.Stdin.Fd()))
+				fmt.Fprintln(cmd.ErrOrStderr())
+				if err != nil {
+					return fmt.Errorf("read secret value: %w", err)
+				}
+				value = string(data)
+			}
+			store, err := NewStore()
+			if err != nil {
+				return err
+			}
+			if err := store.Set(project, resolvedEnv, args[0], value); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Secret %s set for %s/%s\n", args[0], project, resolvedEnv)
+			return nil
+		},
+	}
+
+	getCmd := &cobra.Command{
+		Use:   "get KEY",
+		Short: "Get a secret value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reveal, _ := cmd.Flags().GetBool("reveal")
+			if !reveal {
+				return fmt.Errorf("refusing to print secret without --reveal")
+			}
+			resolvedEnv, err := resolveCLIEnv(project, env)
+			if err != nil {
+				return err
+			}
+			store, err := NewStore()
+			if err != nil {
+				return err
+			}
+			value, err := store.Get(project, resolvedEnv, args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), value)
+			return nil
+		},
+	}
+	getCmd.Flags().Bool("reveal", false, "Print the secret value")
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List secret keys",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reveal, _ := cmd.Flags().GetBool("reveal")
+			resolvedEnv, err := resolveCLIEnv(project, env)
+			if err != nil {
+				return err
+			}
+			store, err := NewStore()
+			if err != nil {
+				return err
+			}
+			if reveal {
+				values, err := store.Load(project, resolvedEnv)
+				if err != nil {
+					return err
+				}
+				for _, key := range sortedSecretKeys(values) {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s=%s\n", key, shellQuote(values[key]))
+				}
+			} else {
+				keys, err := store.List(project, resolvedEnv)
+				if err != nil {
+					return err
+				}
+				for _, key := range keys {
+					fmt.Fprintln(cmd.OutOrStdout(), key)
+				}
+			}
+			return nil
+		},
+	}
+	listCmd.Flags().Bool("reveal", false, "Print secret values")
+
+	exportCmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export secrets",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reveal, _ := cmd.Flags().GetBool("reveal")
+			if !reveal {
+				return fmt.Errorf("refusing to export secrets without --reveal")
+			}
+			format, _ := cmd.Flags().GetString("format")
+			resolvedEnv, err := resolveCLIEnv(project, env)
+			if err != nil {
+				return err
+			}
+			store, err := NewStore()
+			if err != nil {
+				return err
+			}
+			values, err := store.Load(project, resolvedEnv)
+			if err != nil {
+				return err
+			}
+			switch format {
+			case "env":
+				for _, key := range sortedSecretKeys(values) {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s=%s\n", key, shellQuote(values[key]))
+				}
+			case "json":
+				encoded, err := json.MarshalIndent(values, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), string(encoded))
+			default:
+				return fmt.Errorf("unsupported export format %q (use env or json)", format)
+			}
+			return nil
+		},
+	}
+	exportCmd.Flags().Bool("reveal", false, "Print secret values")
+	exportCmd.Flags().String("format", "env", "Export format: env or json")
+
+	removeCmd := &cobra.Command{
+		Use:   "remove KEY",
+		Short: "Remove a secret",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolvedEnv, err := resolveCLIEnv(project, env)
+			if err != nil {
+				return err
+			}
+			store, err := NewStore()
+			if err != nil {
+				return err
+			}
+			if err := store.Remove(project, resolvedEnv, args[0]); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Secret %s removed from %s/%s\n", args[0], project, resolvedEnv)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(setCmd, getCmd, listCmd, exportCmd, removeCmd)
+	return cmd
+}
+
+func sortedSecretKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func resolveCLIEnv(project, flagEnv string) (string, error) {
+	if err := ValidateProject(project); err != nil {
+		return "", err
+	}
+	if flagEnv != "" {
+		if err := ValidateEnv(flagEnv); err != nil {
+			return "", err
+		}
+		return flagEnv, nil
+	}
+	if env, err := projectEnvFromUserConfig(project); err != nil {
+		return "", err
+	} else if env != "" {
+		return env, nil
+	}
+	if env, err := projectEnvFromEnvFile(project); err != nil {
+		return "", err
+	} else if env != "" {
+		return env, nil
+	}
+	return "default", nil
+}
+
+func projectEnvFromUserConfig(project string) (string, error) {
+	uc, err := identity.LoadUserConfig()
+	if err != nil {
+		return "", err
+	}
+	if uc == nil {
+		return "", nil
+	}
+	for _, p := range uc.Projects {
+		if p.ID == project && p.Env != "" {
+			if err := ValidateEnv(p.Env); err != nil {
+				return "", err
+			}
+			return p.Env, nil
+		}
+	}
+	return "", nil
+}
+
+func projectEnvFromEnvFile(project string) (string, error) {
+	paths, err := config.NewBeaconPaths()
+	if err != nil {
+		return "", err
+	}
+	envPath := paths.GetProjectEnvFile(project)
+	values, err := readEnvFile(envPath, os.Environ())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	env := strings.TrimSpace(values["BEACON_PROJECT_ENV"])
+	if env == "" {
+		return "", nil
+	}
+	if err := ValidateEnv(env); err != nil {
+		return "", err
+	}
+	return env, nil
+}

--- a/internal/secrets/cli_test.go
+++ b/internal/secrets/cli_test.go
@@ -2,6 +2,8 @@ package secrets
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -74,4 +76,81 @@ func TestCommandSetListGetRemove(t *testing.T) {
 	if strings.TrimSpace(out) != "" {
 		t.Fatalf("list after remove output = %q, want empty", out)
 	}
+
+	if _, err := run("--project", "myapp", "--env", "prod", "set", "API_KEY", "secret"); err != nil {
+		t.Fatalf("set for unsupported format error = %v", err)
+	}
+	if _, err := run("--project", "myapp", "--env", "prod", "export", "--reveal", "--format", "yaml"); err == nil {
+		t.Fatal("export unsupported format error = nil, want error")
+	}
+}
+
+func TestResolveCLIEnv(t *testing.T) {
+	t.Run("flag beats env file", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("BEACON_HOME", home)
+		configDir := filepath.Join(home, "config", "projects", "myapp")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "env"), []byte("BEACON_PROJECT_ENV=from_file\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		env, err := resolveCLIEnv("myapp", "from_flag")
+		if err != nil {
+			t.Fatalf("resolve flag env error = %v", err)
+		}
+		if env != "from_flag" {
+			t.Fatalf("env = %q, want from_flag", env)
+		}
+
+		env, err = resolveCLIEnv("myapp", "")
+		if err != nil {
+			t.Fatalf("resolve file env error = %v", err)
+		}
+		if env != "from_file" {
+			t.Fatalf("env = %q, want from_file", env)
+		}
+	})
+
+	t.Run("user config beats env file", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("BEACON_HOME", home)
+		if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte("projects:\n  - id: myapp\n    config_path: /tmp/monitor.yml\n    env: from_config\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		configDir := filepath.Join(home, "config", "projects", "myapp")
+		if err := os.MkdirAll(configDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(configDir, "env"), []byte("BEACON_PROJECT_ENV=from_file\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		env, err := resolveCLIEnv("myapp", "")
+		if err != nil {
+			t.Fatalf("resolve env error = %v", err)
+		}
+		if env != "from_config" {
+			t.Fatalf("env = %q, want from_config", env)
+		}
+	})
+
+	t.Run("default and invalid inputs", func(t *testing.T) {
+		t.Setenv("BEACON_HOME", t.TempDir())
+		env, err := resolveCLIEnv("myapp", "")
+		if err != nil {
+			t.Fatalf("resolve default env error = %v", err)
+		}
+		if env != "default" {
+			t.Fatalf("env = %q, want default", env)
+		}
+		if _, err := resolveCLIEnv("bad/project", ""); err == nil {
+			t.Fatal("resolve invalid project error = nil, want error")
+		}
+		if _, err := resolveCLIEnv("myapp", "bad/env"); err == nil {
+			t.Fatal("resolve invalid env error = nil, want error")
+		}
+	})
 }

--- a/internal/secrets/cli_test.go
+++ b/internal/secrets/cli_test.go
@@ -1,0 +1,77 @@
+package secrets
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestCommandSetListGetRemove(t *testing.T) {
+	t.Setenv("BEACON_HOME", t.TempDir())
+
+	run := func(args ...string) (string, error) {
+		cmd := Command()
+		var out bytes.Buffer
+		var errOut bytes.Buffer
+		cmd.SetOut(&out)
+		cmd.SetErr(&errOut)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		return out.String() + errOut.String(), err
+	}
+
+	if _, err := run("--project", "myapp", "--env", "prod", "set", "API_KEY", "secret"); err != nil {
+		t.Fatalf("set error = %v", err)
+	}
+	out, err := run("--project", "myapp", "--env", "prod", "list")
+	if err != nil {
+		t.Fatalf("list error = %v", err)
+	}
+	if strings.TrimSpace(out) != "API_KEY" {
+		t.Fatalf("list output = %q, want API_KEY", out)
+	}
+	out, err = run("--project", "myapp", "--env", "prod", "list", "--reveal")
+	if err != nil {
+		t.Fatalf("list --reveal error = %v", err)
+	}
+	if strings.TrimSpace(out) != "API_KEY='secret'" {
+		t.Fatalf("list --reveal output = %q, want API_KEY='secret'", out)
+	}
+	out, err = run("--project", "myapp", "--env", "prod", "get", "API_KEY", "--reveal")
+	if err != nil {
+		t.Fatalf("get error = %v", err)
+	}
+	if strings.TrimSpace(out) != "secret" {
+		t.Fatalf("get output = %q, want secret", out)
+	}
+	if _, err := run("--project", "myapp", "--env", "prod", "get", "API_KEY"); err == nil {
+		t.Fatal("get without --reveal error = nil, want error")
+	}
+	if _, err := run("--project", "myapp", "--env", "prod", "export"); err == nil {
+		t.Fatal("export without --reveal error = nil, want error")
+	}
+	out, err = run("--project", "myapp", "--env", "prod", "export", "--reveal")
+	if err != nil {
+		t.Fatalf("export env error = %v", err)
+	}
+	if strings.TrimSpace(out) != "API_KEY='secret'" {
+		t.Fatalf("export env output = %q, want API_KEY='secret'", out)
+	}
+	out, err = run("--project", "myapp", "--env", "prod", "export", "--reveal", "--format", "json")
+	if err != nil {
+		t.Fatalf("export json error = %v", err)
+	}
+	if !strings.Contains(out, `"API_KEY": "secret"`) {
+		t.Fatalf("export json output = %q, want API_KEY value", out)
+	}
+	if _, err := run("--project", "myapp", "--env", "prod", "remove", "API_KEY"); err != nil {
+		t.Fatalf("remove error = %v", err)
+	}
+	out, err = run("--project", "myapp", "--env", "prod", "list")
+	if err != nil {
+		t.Fatalf("list after remove error = %v", err)
+	}
+	if strings.TrimSpace(out) != "" {
+		t.Fatalf("list after remove output = %q, want empty", out)
+	}
+}

--- a/internal/secrets/cli_test.go
+++ b/internal/secrets/cli_test.go
@@ -154,3 +154,22 @@ func TestResolveCLIEnv(t *testing.T) {
 		}
 	})
 }
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty", value: "", want: "''"},
+		{name: "plain", value: "secret", want: "'secret'"},
+		{name: "single quote", value: "it'is", want: "'it'\\''is'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shellQuote(tt.value); got != tt.want {
+				t.Fatalf("shellQuote(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/secrets/envfile.go
+++ b/internal/secrets/envfile.go
@@ -1,0 +1,65 @@
+package secrets
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func readEnvFile(path string, baseEnv []string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	values := envSliceToMap(baseEnv)
+	out := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key == "" {
+			continue
+		}
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+		value = expandFromMap(value, values)
+		values[key] = value
+		out[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read env file: %w", err)
+	}
+	return out, nil
+}
+
+func envSliceToMap(env []string) map[string]string {
+	values := map[string]string{}
+	for _, item := range env {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) == 2 {
+			values[parts[0]] = parts[1]
+		}
+	}
+	return values
+}
+
+func expandFromMap(value string, values map[string]string) string {
+	return os.Expand(value, func(key string) string {
+		return values[key]
+	})
+}

--- a/internal/secrets/envfile.go
+++ b/internal/secrets/envfile.go
@@ -1,67 +1,7 @@
 package secrets
 
-import (
-	"bufio"
-	"fmt"
-	"os"
-	"strings"
-
-	"beacon/internal/util"
-)
+import "beacon/internal/util"
 
 func readEnvFile(path string, baseEnv []string) (map[string]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer util.DeferClose(file, "env file")()
-
-	values := envSliceToMap(baseEnv)
-	out := map[string]string{}
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		if key == "" {
-			continue
-		}
-		if len(value) >= 2 {
-			if (value[0] == '"' && value[len(value)-1] == '"') ||
-				(value[0] == '\'' && value[len(value)-1] == '\'') {
-				value = value[1 : len(value)-1]
-			}
-		}
-		value = expandFromMap(value, values)
-		values[key] = value
-		out[key] = value
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("read env file: %w", err)
-	}
-	return out, nil
-}
-
-func envSliceToMap(env []string) map[string]string {
-	values := map[string]string{}
-	for _, item := range env {
-		parts := strings.SplitN(item, "=", 2)
-		if len(parts) == 2 {
-			values[parts[0]] = parts[1]
-		}
-	}
-	return values
-}
-
-func expandFromMap(value string, values map[string]string) string {
-	return os.Expand(value, func(key string) string {
-		return values[key]
-	})
+	return util.ReadEnvFileMap(path, util.EnvSliceToMap(baseEnv))
 }

--- a/internal/secrets/envfile.go
+++ b/internal/secrets/envfile.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"beacon/internal/util"
 )
 
 func readEnvFile(path string, baseEnv []string) (map[string]string, error) {
@@ -12,7 +14,7 @@ func readEnvFile(path string, baseEnv []string) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer util.DeferClose(file, "env file")()
 
 	values := envSliceToMap(baseEnv)
 	out := map[string]string{}

--- a/internal/secrets/envfile_test.go
+++ b/internal/secrets/envfile_test.go
@@ -1,0 +1,50 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadEnvFile(t *testing.T) {
+	t.Run("parses and expands", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "env")
+		content := `
+# comment
+PLAIN=value
+DOUBLE="two words"
+SINGLE='single words'
+EXPANDED=${BASE}/suffix
+MALFORMED
+=empty-key
+`
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		values, err := readEnvFile(path, []string{"BASE=/tmp/base"})
+		if err != nil {
+			t.Fatalf("readEnvFile() error = %v", err)
+		}
+		want := map[string]string{
+			"PLAIN":    "value",
+			"DOUBLE":   "two words",
+			"SINGLE":   "single words",
+			"EXPANDED": "/tmp/base/suffix",
+		}
+		for key, expected := range want {
+			if values[key] != expected {
+				t.Fatalf("%s = %q, want %q", key, values[key], expected)
+			}
+		}
+		if _, ok := values["MALFORMED"]; ok {
+			t.Fatal("malformed line was parsed")
+		}
+	})
+
+	t.Run("missing file errors", func(t *testing.T) {
+		if _, err := readEnvFile(filepath.Join(t.TempDir(), "missing"), nil); err == nil {
+			t.Fatal("readEnvFile() error = nil, want missing file error")
+		}
+	})
+}

--- a/internal/secrets/logging.go
+++ b/internal/secrets/logging.go
@@ -1,0 +1,5 @@
+package secrets
+
+import "beacon/internal/logging"
+
+var logger = logging.New("secrets")

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -187,7 +187,7 @@ func (s *Store) save(project, env string, values map[string]string) error {
 	if err := os.MkdirAll(filepath.Dir(path), secretsDirMode); err != nil {
 		return err
 	}
-	return os.WriteFile(path, encrypted, secretFileMode)
+	return writeFileAtomic(path, encrypted, secretFileMode)
 }
 
 func (s *Store) loadOrCreateKey() ([]byte, error) {
@@ -215,18 +215,67 @@ func (s *Store) loadOrCreateKey() ([]byte, error) {
 	if _, err := io.ReadFull(rand.Reader, key); err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(s.keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, keyFileMode)
-	if err != nil {
-		return nil, err
-	}
-	if _, err := f.Write(key); err != nil {
-		_ = f.Close()
-		return nil, err
-	}
-	if err := f.Close(); err != nil {
+	if err := writeFileExclusive(s.keyPath, key, keyFileMode); err != nil {
+		if os.IsExist(err) {
+			return s.loadOrCreateKey()
+		}
 		return nil, err
 	}
 	return key, nil
+}
+
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	keepTmp := true
+	defer func() {
+		if keepTmp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	keepTmp = false
+	return nil
+}
+
+func writeFileExclusive(path string, data []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func encrypt(key, plain []byte) ([]byte, error) {

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -1,0 +1,320 @@
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"beacon/internal/config"
+)
+
+const (
+	keySize         = 32
+	keyFileMode     = 0600
+	secretsDirMode  = 0700
+	secretFileMode  = 0600
+	envelopeVersion = 1
+)
+
+var ErrNotFound = errors.New("secret not found")
+
+type envelope struct {
+	Version    int    `json:"version"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+type Store struct {
+	baseDir string
+	keyPath string
+}
+
+func NewStore() (*Store, error) {
+	base, err := config.BeaconHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("beacon home: %w", err)
+	}
+	secretsDir := filepath.Join(base, "secrets")
+	return &Store{
+		baseDir: secretsDir,
+		keyPath: filepath.Join(secretsDir, "key"),
+	}, nil
+}
+
+func NewStoreAt(baseDir string) *Store {
+	return &Store{
+		baseDir: baseDir,
+		keyPath: filepath.Join(baseDir, "key"),
+	}
+}
+
+func (s *Store) Path(project, env string) (string, error) {
+	if err := ValidateProject(project); err != nil {
+		return "", err
+	}
+	if err := ValidateEnv(env); err != nil {
+		return "", err
+	}
+	return filepath.Join(s.baseDir, project, env+".enc"), nil
+}
+
+func (s *Store) Exists(project, env string) (bool, error) {
+	path, err := s.Path(project, env)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (s *Store) Load(project, env string) (map[string]string, error) {
+	path, err := s.Path(project, env)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	key, err := s.loadOrCreateKey()
+	if err != nil {
+		return nil, err
+	}
+	plain, err := decrypt(key, data)
+	if err != nil {
+		return nil, err
+	}
+	var values map[string]string
+	if err := json.Unmarshal(plain, &values); err != nil {
+		return nil, fmt.Errorf("parse secrets payload: %w", err)
+	}
+	if values == nil {
+		values = map[string]string{}
+	}
+	return values, nil
+}
+
+func (s *Store) Set(project, env, key, value string) error {
+	if err := ValidateSecretKey(key); err != nil {
+		return err
+	}
+	values, err := s.Load(project, env)
+	if err != nil {
+		return err
+	}
+	values[key] = value
+	return s.save(project, env, values)
+}
+
+func (s *Store) Get(project, env, key string) (string, error) {
+	if err := ValidateSecretKey(key); err != nil {
+		return "", err
+	}
+	values, err := s.Load(project, env)
+	if err != nil {
+		return "", err
+	}
+	value, ok := values[key]
+	if !ok {
+		return "", ErrNotFound
+	}
+	return value, nil
+}
+
+func (s *Store) List(project, env string) ([]string, error) {
+	values, err := s.Load(project, env)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func (s *Store) Remove(project, env, key string) error {
+	if err := ValidateSecretKey(key); err != nil {
+		return err
+	}
+	values, err := s.Load(project, env)
+	if err != nil {
+		return err
+	}
+	if _, ok := values[key]; !ok {
+		return ErrNotFound
+	}
+	delete(values, key)
+	return s.save(project, env, values)
+}
+
+func (s *Store) save(project, env string, values map[string]string) error {
+	path, err := s.Path(project, env)
+	if err != nil {
+		return err
+	}
+	key, err := s.loadOrCreateKey()
+	if err != nil {
+		return err
+	}
+	plain, err := json.Marshal(values)
+	if err != nil {
+		return err
+	}
+	encrypted, err := encrypt(key, plain)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), secretsDirMode); err != nil {
+		return err
+	}
+	return os.WriteFile(path, encrypted, secretFileMode)
+}
+
+func (s *Store) loadOrCreateKey() ([]byte, error) {
+	if err := os.MkdirAll(s.baseDir, secretsDirMode); err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(s.keyPath)
+	if err == nil {
+		if info.Mode().Perm() != keyFileMode {
+			return nil, fmt.Errorf("secrets key %s has permissions %o, want 600", s.keyPath, info.Mode().Perm())
+		}
+		key, err := os.ReadFile(s.keyPath)
+		if err != nil {
+			return nil, err
+		}
+		if len(key) != keySize {
+			return nil, fmt.Errorf("secrets key %s has invalid length %d", s.keyPath, len(key))
+		}
+		return key, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, err
+	}
+	key := make([]byte, keySize)
+	if _, err := io.ReadFull(rand.Reader, key); err != nil {
+		return nil, err
+	}
+	f, err := os.OpenFile(s.keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, keyFileMode)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if _, err := f.Write(key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func encrypt(key, plain []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+	env := envelope{
+		Version:    envelopeVersion,
+		Nonce:      base64.StdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.StdEncoding.EncodeToString(gcm.Seal(nil, nonce, plain, nil)),
+	}
+	return json.Marshal(env)
+}
+
+func decrypt(key, data []byte) ([]byte, error) {
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("parse encrypted secrets envelope: %w", err)
+	}
+	if env.Version != envelopeVersion {
+		return nil, fmt.Errorf("unsupported secrets envelope version %d", env.Version)
+	}
+	nonce, err := base64.StdEncoding.DecodeString(env.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("decode nonce: %w", err)
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(env.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decode ciphertext: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt secrets: %w", err)
+	}
+	return plain, nil
+}
+
+func ValidateProject(name string) error {
+	paths, err := config.NewBeaconPaths()
+	if err != nil {
+		return err
+	}
+	return paths.ValidateProjectName(name)
+}
+
+func ValidateEnv(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("env name cannot be empty")
+	}
+	return validateSafeName("env name", name)
+}
+
+func ValidateSecretKey(key string) error {
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("secret key cannot be empty")
+	}
+	for _, char := range key {
+		if (char < 'A' || char > 'Z') &&
+			(char < '0' || char > '9') &&
+			char != '_' {
+			return fmt.Errorf("secret key contains invalid character %q. Only uppercase letters, numbers, and underscores are allowed", char)
+		}
+	}
+	return nil
+}
+
+func validateSafeName(label, name string) error {
+	for _, char := range name {
+		if (char < 'a' || char > 'z') &&
+			(char < 'A' || char > 'Z') &&
+			(char < '0' || char > '9') &&
+			char != '-' && char != '_' {
+			return fmt.Errorf("%s contains invalid character %q. Only letters, numbers, hyphens, and underscores are allowed", label, char)
+		}
+	}
+	return nil
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -256,7 +256,26 @@ func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
 		return err
 	}
 	keepTmp = false
+	syncDir(dir)
 	return nil
+}
+
+// syncDir best-effort fsyncs a directory so that a preceding rename/create is
+// durable across a crash. The data was already written and renamed
+// successfully, so a sync failure is non-fatal: it is only logged as a warning.
+// Some filesystems and platforms do not support syncing a directory handle.
+func syncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		logger.Warnf("could not open directory %s to fsync: %v", dir, err)
+		return
+	}
+	if err := d.Sync(); err != nil {
+		logger.Warnf("could not fsync directory %s: %v", dir, err)
+	}
+	if err := d.Close(); err != nil {
+		logger.Warnf("could not close directory %s after fsync: %v", dir, err)
+	}
 }
 
 func writeFileExclusive(path string, data []byte, mode os.FileMode) error {
@@ -275,6 +294,7 @@ func writeFileExclusive(path string, data []byte, mode os.FileMode) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
+	syncDir(filepath.Dir(path))
 	return nil
 }
 

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -219,8 +219,11 @@ func (s *Store) loadOrCreateKey() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 	if _, err := f.Write(key); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
 		return nil, err
 	}
 	return key, nil

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -57,8 +57,22 @@ func TestStoreKeyHandling(t *testing.T) {
 
 func TestStoreSetListGetRemove(t *testing.T) {
 	store := NewStoreAt(t.TempDir())
+	exists, err := store.Exists("myapp", "prod")
+	if err != nil {
+		t.Fatalf("Exists() before set error = %v", err)
+	}
+	if exists {
+		t.Fatal("Exists() before set = true, want false")
+	}
 	if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
 		t.Fatalf("Set() error = %v", err)
+	}
+	exists, err = store.Exists("myapp", "prod")
+	if err != nil {
+		t.Fatalf("Exists() after set error = %v", err)
+	}
+	if !exists {
+		t.Fatal("Exists() after set = false, want true")
 	}
 	keys, err := store.List("myapp", "prod")
 	if err != nil {
@@ -79,6 +93,9 @@ func TestStoreSetListGetRemove(t *testing.T) {
 	}
 	if _, err := store.Get("myapp", "prod", "TOKEN"); err != ErrNotFound {
 		t.Fatalf("Get() after remove error = %v, want ErrNotFound", err)
+	}
+	if err := store.Remove("myapp", "prod", "TOKEN"); err != ErrNotFound {
+		t.Fatalf("Remove() after remove error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -74,6 +75,17 @@ func TestStoreSetListGetRemove(t *testing.T) {
 	if !exists {
 		t.Fatal("Exists() after set = false, want true")
 	}
+	secretPath, err := store.Path("myapp", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(secretPath)
+	if err != nil {
+		t.Fatalf("stat secret file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != secretFileMode {
+		t.Fatalf("secret file mode = %o, want %o", got, secretFileMode)
+	}
 	keys, err := store.List("myapp", "prod")
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
@@ -97,6 +109,59 @@ func TestStoreSetListGetRemove(t *testing.T) {
 	if err := store.Remove("myapp", "prod", "TOKEN"); err != ErrNotFound {
 		t.Fatalf("Remove() after remove error = %v, want ErrNotFound", err)
 	}
+}
+
+func TestStoreFileWrites(t *testing.T) {
+	t.Run("atomic replace writes complete file with requested mode", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "prod.enc")
+		if err := writeFileAtomic(path, []byte("old"), secretFileMode); err != nil {
+			t.Fatalf("writeFileAtomic() first error = %v", err)
+		}
+		if err := writeFileAtomic(path, []byte("new"), secretFileMode); err != nil {
+			t.Fatalf("writeFileAtomic() second error = %v", err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "new" {
+			t.Fatalf("file contents = %q, want new", data)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := info.Mode().Perm(); got != secretFileMode {
+			t.Fatalf("file mode = %o, want %o", got, secretFileMode)
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, entry := range entries {
+			if strings.Contains(entry.Name(), ".prod.enc.tmp-") {
+				t.Fatalf("temporary file was not cleaned up: %s", entry.Name())
+			}
+		}
+	})
+
+	t.Run("exclusive write refuses to clobber existing key", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "key")
+		if err := writeFileExclusive(path, []byte("old"), keyFileMode); err != nil {
+			t.Fatalf("writeFileExclusive() first error = %v", err)
+		}
+		if err := writeFileExclusive(path, []byte("new"), keyFileMode); !os.IsExist(err) {
+			t.Fatalf("writeFileExclusive() second error = %v, want exists", err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "old" {
+			t.Fatalf("file contents = %q, want old", data)
+		}
+	})
 }
 
 func TestStoreProjectEnvIsolation(t *testing.T) {

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -113,3 +113,64 @@ func TestStoreCorruptedEncryptedFileFails(t *testing.T) {
 		t.Fatal("Load() error = nil, want corrupted file error")
 	}
 }
+
+func TestStoreMissingFileLoadsEmpty(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	values, err := store.Load("myapp", "missing")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(values) != 0 {
+		t.Fatalf("Load() = %#v, want empty map", values)
+	}
+}
+
+func TestStoreValidatesNamesAndKeys(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"project path", store.Set("bad/project", "prod", "TOKEN", "x")},
+		{"env path", store.Set("myapp", "bad/env", "TOKEN", "x")},
+		{"empty env", store.Set("myapp", "", "TOKEN", "x")},
+		{"lowercase key", store.Set("myapp", "prod", "token", "x")},
+		{"dashed key", store.Set("myapp", "prod", "BAD-KEY", "x")},
+	}
+	for _, tt := range tests {
+		if tt.err == nil {
+			t.Fatalf("%s error = nil, want validation error", tt.name)
+		}
+	}
+}
+
+func TestStoreRejectsInvalidKeyLength(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "key"), []byte("short"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStoreAt(dir)
+	if err := store.Set("myapp", "prod", "TOKEN", "x"); err == nil {
+		t.Fatal("Set() error = nil, want invalid key length error")
+	}
+}
+
+func TestStoreCorruptedPayloadFails(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := store.Path("myapp", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"version":1,"nonce":"@@","ciphertext":"abc"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Load("myapp", "prod"); err == nil {
+		t.Fatal("Load() error = nil, want invalid nonce error")
+	}
+}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -1,0 +1,115 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestStoreKeyGenerationAndMode(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	if err := store.Set("myapp", "default", "API_KEY", "secret"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	info, err := os.Stat(store.keyPath)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if got := info.Mode().Perm(); got != keyFileMode {
+		t.Fatalf("key mode = %o, want %o", got, keyFileMode)
+	}
+}
+
+func TestStoreRejectsOpenKeyPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix file permission test")
+	}
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, "key")
+	if err := os.WriteFile(keyPath, make([]byte, keySize), 0644); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStoreAt(dir)
+	if err := store.Set("myapp", "default", "API_KEY", "secret"); err == nil {
+		t.Fatal("Set() error = nil, want permission error")
+	}
+}
+
+func TestStoreSetListGetRemove(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	keys, err := store.List("myapp", "prod")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(keys) != 1 || keys[0] != "TOKEN" {
+		t.Fatalf("List() = %#v, want TOKEN", keys)
+	}
+	value, err := store.Get("myapp", "prod", "TOKEN")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if value != "abc" {
+		t.Fatalf("Get() = %q, want abc", value)
+	}
+	if err := store.Remove("myapp", "prod", "TOKEN"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if _, err := store.Get("myapp", "prod", "TOKEN"); err != ErrNotFound {
+		t.Fatalf("Get() after remove error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreProjectEnvIsolation(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	if err := store.Set("myapp", "prod", "TOKEN", "prod"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("myapp", "staging", "TOKEN", "staging"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set("otherapp", "prod", "TOKEN", "other"); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		project string
+		env     string
+		want    string
+	}{
+		{"myapp", "prod", "prod"},
+		{"myapp", "staging", "staging"},
+		{"otherapp", "prod", "other"},
+	}
+	for _, tt := range tests {
+		got, err := store.Get(tt.project, tt.env, "TOKEN")
+		if err != nil {
+			t.Fatalf("Get(%s/%s) error = %v", tt.project, tt.env, err)
+		}
+		if got != tt.want {
+			t.Fatalf("Get(%s/%s) = %q, want %q", tt.project, tt.env, got, tt.want)
+		}
+	}
+}
+
+func TestStoreCorruptedEncryptedFileFails(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
+		t.Fatal(err)
+	}
+	path, err := store.Path("myapp", "prod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("not-json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Load("myapp", "prod"); err == nil {
+		t.Fatal("Load() error = nil, want corrupted file error")
+	}
+}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -7,36 +7,52 @@ import (
 	"testing"
 )
 
-func TestStoreKeyGenerationAndMode(t *testing.T) {
-	store := NewStoreAt(t.TempDir())
-	if err := store.Set("myapp", "default", "API_KEY", "secret"); err != nil {
-		t.Fatalf("Set() error = %v", err)
-	}
-	info, err := os.Stat(store.keyPath)
-	if err != nil {
-		t.Fatalf("stat key: %v", err)
-	}
-	if got := info.Mode().Perm(); got != keyFileMode {
-		t.Fatalf("key mode = %o, want %o", got, keyFileMode)
-	}
-}
+func TestStoreKeyHandling(t *testing.T) {
+	t.Run("generation and mode", func(t *testing.T) {
+		store := NewStoreAt(t.TempDir())
+		if err := store.Set("myapp", "default", "API_KEY", "secret"); err != nil {
+			t.Fatalf("Set() error = %v", err)
+		}
+		info, err := os.Stat(store.keyPath)
+		if err != nil {
+			t.Fatalf("stat key: %v", err)
+		}
+		if got := info.Mode().Perm(); got != keyFileMode {
+			t.Fatalf("key mode = %o, want %o", got, keyFileMode)
+		}
+	})
 
-func TestStoreRejectsOpenKeyPermissions(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("unix file permission test")
-	}
-	dir := t.TempDir()
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		t.Fatal(err)
-	}
-	keyPath := filepath.Join(dir, "key")
-	if err := os.WriteFile(keyPath, make([]byte, keySize), 0644); err != nil {
-		t.Fatal(err)
-	}
-	store := NewStoreAt(dir)
-	if err := store.Set("myapp", "default", "API_KEY", "secret"); err == nil {
-		t.Fatal("Set() error = nil, want permission error")
-	}
+	t.Run("rejects open permissions", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("unix file permission test")
+		}
+		dir := t.TempDir()
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		keyPath := filepath.Join(dir, "key")
+		if err := os.WriteFile(keyPath, make([]byte, keySize), 0644); err != nil {
+			t.Fatal(err)
+		}
+		store := NewStoreAt(dir)
+		if err := store.Set("myapp", "default", "API_KEY", "secret"); err == nil {
+			t.Fatal("Set() error = nil, want permission error")
+		}
+	})
+
+	t.Run("rejects invalid key length", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "key"), []byte("short"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		store := NewStoreAt(dir)
+		if err := store.Set("myapp", "prod", "TOKEN", "x"); err == nil {
+			t.Fatal("Set() error = nil, want invalid key length error")
+		}
+	})
 }
 
 func TestStoreSetListGetRemove(t *testing.T) {
@@ -97,32 +113,51 @@ func TestStoreProjectEnvIsolation(t *testing.T) {
 	}
 }
 
-func TestStoreCorruptedEncryptedFileFails(t *testing.T) {
-	store := NewStoreAt(t.TempDir())
-	if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
-		t.Fatal(err)
-	}
-	path, err := store.Path("myapp", "prod")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte("not-json"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := store.Load("myapp", "prod"); err == nil {
-		t.Fatal("Load() error = nil, want corrupted file error")
-	}
-}
+func TestStoreLoad(t *testing.T) {
+	t.Run("missing file loads empty", func(t *testing.T) {
+		store := NewStoreAt(t.TempDir())
+		values, err := store.Load("myapp", "missing")
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if len(values) != 0 {
+			t.Fatalf("Load() = %#v, want empty map", values)
+		}
+	})
 
-func TestStoreMissingFileLoadsEmpty(t *testing.T) {
-	store := NewStoreAt(t.TempDir())
-	values, err := store.Load("myapp", "missing")
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-	if len(values) != 0 {
-		t.Fatalf("Load() = %#v, want empty map", values)
-	}
+	t.Run("corrupted envelope fails", func(t *testing.T) {
+		store := NewStoreAt(t.TempDir())
+		if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
+			t.Fatal(err)
+		}
+		path, err := store.Path("myapp", "prod")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("not-json"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Load("myapp", "prod"); err == nil {
+			t.Fatal("Load() error = nil, want corrupted file error")
+		}
+	})
+
+	t.Run("corrupted payload fails", func(t *testing.T) {
+		store := NewStoreAt(t.TempDir())
+		if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
+			t.Fatal(err)
+		}
+		path, err := store.Path("myapp", "prod")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(`{"version":1,"nonce":"@@","ciphertext":"abc"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Load("myapp", "prod"); err == nil {
+			t.Fatal("Load() error = nil, want invalid nonce error")
+		}
+	})
 }
 
 func TestStoreValidatesNamesAndKeys(t *testing.T) {
@@ -141,36 +176,5 @@ func TestStoreValidatesNamesAndKeys(t *testing.T) {
 		if tt.err == nil {
 			t.Fatalf("%s error = nil, want validation error", tt.name)
 		}
-	}
-}
-
-func TestStoreRejectsInvalidKeyLength(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "key"), []byte("short"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	store := NewStoreAt(dir)
-	if err := store.Set("myapp", "prod", "TOKEN", "x"); err == nil {
-		t.Fatal("Set() error = nil, want invalid key length error")
-	}
-}
-
-func TestStoreCorruptedPayloadFails(t *testing.T) {
-	store := NewStoreAt(t.TempDir())
-	if err := store.Set("myapp", "prod", "TOKEN", "abc"); err != nil {
-		t.Fatal(err)
-	}
-	path, err := store.Path("myapp", "prod")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte(`{"version":1,"nonce":"@@","ciphertext":"abc"}`), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := store.Load("myapp", "prod"); err == nil {
-		t.Fatal("Load() error = nil, want invalid nonce error")
 	}
 }

--- a/internal/util/envparse.go
+++ b/internal/util/envparse.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ReadEnvFileMap reads KEY=value lines from path, expanding values using baseEnv
+// plus keys already parsed earlier in the same file. It returns only values
+// defined by the file, not the full base environment.
+func ReadEnvFileMap(path string, baseEnv map[string]string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer DeferClose(file, "env file")()
+
+	values := make(map[string]string, len(baseEnv))
+	for key, value := range baseEnv {
+		values[key] = value
+	}
+	out := map[string]string{}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key == "" {
+			continue
+		}
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') ||
+				(value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+		value = os.Expand(value, func(key string) string {
+			return values[key]
+		})
+		values[key] = value
+		out[key] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read env file: %w", err)
+	}
+	return out, nil
+}
+
+func EnvSliceToMap(env []string) map[string]string {
+	values := map[string]string{}
+	for _, item := range env {
+		parts := strings.SplitN(item, "=", 2)
+		if len(parts) == 2 {
+			values[parts[0]] = parts[1]
+		}
+	}
+	return values
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -618,6 +618,8 @@ func (w *Wizard) writeEnvFile(pluginConfigs []plugins.PluginConfig, reportConfig
 	content.WriteString("BEACON_POLL_INTERVAL=60s\n\n")
 	content.WriteString("# HTTP server port\n")
 	content.WriteString("BEACON_PORT=8080\n\n")
+	content.WriteString("# Project environment for Beacon-managed secrets (optional)\n")
+	content.WriteString("# BEACON_PROJECT_ENV=default\n\n")
 
 	// Add plugin environment variables
 	content.WriteString("# Plugin Configuration\n")
@@ -659,6 +661,7 @@ func (w *Wizard) writeBootstrapConfig() error {
 
 	content.WriteString("# Project configuration\n")
 	content.WriteString("project_name: \"my-project\"  # Will be overridden by bootstrap command\n")
+	content.WriteString("# project_env: \"default\"  # Optional environment for Beacon-managed secrets\n")
 	content.WriteString("repo_url: \"https://github.com/username/my-repo.git\"\n")
 	content.WriteString("local_path: \"$HOME/beacon/my-project\"\n")
 	content.WriteString("deploy_command: \"./deploy.sh\"  # Or: docker compose up --build -d\n")

--- a/tests/e2e/test-cli.sh
+++ b/tests/e2e/test-cli.sh
@@ -186,6 +186,91 @@ test_cloud_login_logout() {
     log_success "beacon cloud login / cloud logout OK"
 }
 
+test_secrets_cli() {
+    log_info "Testing Beacon secrets CLI..."
+
+    local secrets_home="/tmp/beacon-e2e-secrets-home"
+    rm -rf "$secrets_home"
+    mkdir -p "$secrets_home"
+
+    if ! BEACON_HOME="$secrets_home" beacon secrets set API_TOKEN "secret-one" --project "$PROJECT_NAME" --env prod; then
+        log_error "beacon secrets set API_TOKEN failed"
+        exit 1
+    fi
+    if ! BEACON_HOME="$secrets_home" beacon secrets set DB_PASSWORD "secret-two" --project "$PROJECT_NAME" --env prod; then
+        log_error "beacon secrets set DB_PASSWORD failed"
+        exit 1
+    fi
+
+    local list_output
+    list_output=$(BEACON_HOME="$secrets_home" beacon secrets list --project "$PROJECT_NAME" --env prod)
+    if ! echo "$list_output" | grep -qx "API_TOKEN"; then
+        log_error "secrets list missing API_TOKEN"
+        echo "$list_output"
+        exit 1
+    fi
+    if ! echo "$list_output" | grep -qx "DB_PASSWORD"; then
+        log_error "secrets list missing DB_PASSWORD"
+        echo "$list_output"
+        exit 1
+    fi
+    if echo "$list_output" | grep -q "secret-one"; then
+        log_error "secrets list leaked secret value without --reveal"
+        echo "$list_output"
+        exit 1
+    fi
+    log_success "✓ secrets list prints keys only"
+
+    local reveal_output
+    reveal_output=$(BEACON_HOME="$secrets_home" beacon secrets list --reveal --project "$PROJECT_NAME" --env prod)
+    if ! echo "$reveal_output" | grep -qx "API_TOKEN='secret-one'"; then
+        log_error "secrets list --reveal missing API_TOKEN value"
+        echo "$reveal_output"
+        exit 1
+    fi
+    if ! echo "$reveal_output" | grep -qx "DB_PASSWORD='secret-two'"; then
+        log_error "secrets list --reveal missing DB_PASSWORD value"
+        echo "$reveal_output"
+        exit 1
+    fi
+    log_success "✓ secrets list --reveal prints values"
+
+    local export_env_output
+    export_env_output=$(BEACON_HOME="$secrets_home" beacon secrets export --reveal --project "$PROJECT_NAME" --env prod)
+    if ! echo "$export_env_output" | grep -qx "API_TOKEN='secret-one'"; then
+        log_error "secrets export --reveal missing API_TOKEN value"
+        echo "$export_env_output"
+        exit 1
+    fi
+
+    local export_json_output
+    export_json_output=$(BEACON_HOME="$secrets_home" beacon secrets export --reveal --format json --project "$PROJECT_NAME" --env prod)
+    if ! echo "$export_json_output" | grep -q '"API_TOKEN": "secret-one"'; then
+        log_error "secrets export --format json missing API_TOKEN value"
+        echo "$export_json_output"
+        exit 1
+    fi
+    log_success "✓ secrets export supports env and json formats"
+
+    if BEACON_HOME="$secrets_home" beacon secrets export --project "$PROJECT_NAME" --env prod >/tmp/beacon-secrets-export.log 2>&1; then
+        log_error "secrets export without --reveal unexpectedly succeeded"
+        exit 1
+    fi
+    log_success "✓ secrets export requires --reveal"
+
+    if ! BEACON_HOME="$secrets_home" beacon secrets remove API_TOKEN --project "$PROJECT_NAME" --env prod; then
+        log_error "beacon secrets remove failed"
+        exit 1
+    fi
+    list_output=$(BEACON_HOME="$secrets_home" beacon secrets list --project "$PROJECT_NAME" --env prod)
+    if echo "$list_output" | grep -qx "API_TOKEN"; then
+        log_error "secrets remove did not remove API_TOKEN"
+        echo "$list_output"
+        exit 1
+    fi
+    log_success "Beacon secrets CLI OK"
+}
+
 # Create mock Git repository (local bare repo)
 create_mock_git_repo() {
     log_info "Setting up mock Git repository..."
@@ -1134,6 +1219,7 @@ main() {
     check_prerequisites
     test_canonical_local_flow
     test_cloud_login_logout
+    test_secrets_cli
     create_mock_git_repo
     start_git_http_server
     test_wizard

--- a/tests/e2e/test-cli.sh
+++ b/tests/e2e/test-cli.sh
@@ -189,9 +189,10 @@ test_cloud_login_logout() {
 test_secrets_cli() {
     log_info "Testing Beacon secrets CLI..."
 
-    local secrets_home="/tmp/beacon-e2e-secrets-home"
-    rm -rf "$secrets_home"
-    mkdir -p "$secrets_home"
+    local secrets_home
+    secrets_home=$(mktemp -d /tmp/beacon-e2e-secrets-home.XXXXXX)
+    local export_log
+    export_log=$(mktemp /tmp/beacon-secrets-export.XXXXXX.log)
 
     if ! BEACON_HOME="$secrets_home" beacon secrets set API_TOKEN "secret-one" --project "$PROJECT_NAME" --env prod; then
         log_error "beacon secrets set API_TOKEN failed"
@@ -252,7 +253,7 @@ test_secrets_cli() {
     fi
     log_success "✓ secrets export supports env and json formats"
 
-    if BEACON_HOME="$secrets_home" beacon secrets export --project "$PROJECT_NAME" --env prod >/tmp/beacon-secrets-export.log 2>&1; then
+    if BEACON_HOME="$secrets_home" beacon secrets export --project "$PROJECT_NAME" --env prod >"$export_log" 2>&1; then
         log_error "secrets export without --reveal unexpectedly succeeded"
         exit 1
     fi
@@ -269,6 +270,8 @@ test_secrets_cli() {
         exit 1
     fi
     log_success "Beacon secrets CLI OK"
+    rm -rf "$secrets_home"
+    rm -f "$export_log"
 }
 
 # Create mock Git repository (local bare repo)

--- a/tests/e2e/test-cli.sh
+++ b/tests/e2e/test-cli.sh
@@ -190,9 +190,9 @@ test_secrets_cli() {
     log_info "Testing Beacon secrets CLI..."
 
     local secrets_home
-    secrets_home=$(mktemp -d /tmp/beacon-e2e-secrets-home.XXXXXX)
+    secrets_home=$(mktemp -d)
     local export_log
-    export_log=$(mktemp /tmp/beacon-secrets-export.XXXXXX.log)
+    export_log=$(mktemp)
 
     if ! BEACON_HOME="$secrets_home" beacon secrets set API_TOKEN "secret-one" --project "$PROJECT_NAME" --env prod; then
         log_error "beacon secrets set API_TOKEN failed"


### PR DESCRIPTION
## Summary

Adds Beacon-managed encrypted secrets per project and deployment environment, while preserving existing `BEACON_SECURE_ENV_PATH` `.env` behavior. Secrets are stored locally under `~/.beacon/secrets/<project>/<env>.enc`, encrypted with an auto-generated machine key at `~/.beacon/secrets/key`, and injected into deploy commands after `.env` values so Beacon secrets take precedence.

## What Changed

- Added `internal/secrets` with:
  - AES-256-GCM encrypted JSON envelopes
  - strict `0600` machine key creation and validation
  - project/environment path validation
  - `Set`, `Get`, `List`, `Remove`, `Exists`, and `Load` store operations
- Added `beacon secrets` CLI:
  - `set KEY [VALUE] --project <project> [--env <env>]`
  - `get KEY --project <project> [--env <env>] --reveal`
  - `list --project <project> [--env <env>]`
  - `list --reveal --project <project> [--env <env>]`
  - `export --reveal --format env|json --project <project> [--env <env>]`
  - `remove KEY --project <project> [--env <env>]`
- Added project environment support:
  - `projects[].env` in `~/.beacon/config.yaml`
  - `BEACON_PROJECT_ENV`, defaulting to `default`
  - `BEACON_SECRETS_ENABLED` for explicit deploy-time enable/disable
- Reworked deploy environment handling:
  - central helper starts from `os.Environ()`
  - loads existing secure `.env` when present
  - overlays Beacon secrets when enabled or when a secrets file exists
  - passes merged env directly to child commands instead of shell-prefix sourcing
- Wired merged env handling through Git deploy, branch deploy, Docker deploy, redeploy/MCP/monitor-triggered deploy paths through the shared deploy flow.
- Added e2e CLI coverage for setting, listing, revealing, exporting, and removing secrets.
- Fixed CI/lint fallout from the new code and stabilized the async backup test under `-race`.

## Security Notes

- Secret values are never printed by default.
- Commands that print values require explicit `--reveal`.
- `list` remains key-only unless `--reveal` is provided.
- `export` refuses to run without `--reveal`.
- Deploy command logging still logs only the command string, not injected env values.

## Verification

- `go vet ./...`
- `golangci-lint run` / repo lint path: `0 issues`
- `go test ./...`
- `make test`
- `make build`
- `make ci` was started and passed vet/lint locally, then stopped in this environment because `govulncheck` is not installed.

## Notes

- Existing `BEACON_SECURE_ENV_PATH` behavior is preserved.
- Beacon secrets intentionally override `.env` values during deploy.
- The live terminal/editor UX is left out of this PR; the new `list --reveal` and `export --reveal` commands cover the immediate inspection/export use cases.
